### PR TITLE
feat: per-table developer visibility settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ vite.config.ts.timestamp-*
 
 data.json
 excluded-prs.json
+hidden-developers.json

--- a/src/lib/services/developer-visibility.test.ts
+++ b/src/lib/services/developer-visibility.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import {
+	DeveloperVisibilityService,
+	apply_visibility_filter,
+	list_dashboard_developers
+} from './developer-visibility';
+import type { ICodeReviewsData, IDeveloperVisibility } from '../../types';
+
+vi.mock('fs');
+
+const make_data = (overrides: Partial<ICodeReviewsData> = {}): ICodeReviewsData => ({
+	last_synced: '2025-12-23T00:00:00.000Z',
+	status: 'synced',
+	data: {
+		alice: { '2025-12-22': 3, '2025-12-23': 1 },
+		bob: { '2025-12-22': 0, '2025-12-23': 2 }
+	},
+	pr_sizes: {
+		alice: { min: 1, max: 10, avg: 5, pr_count: 2 },
+		manager: { min: 500, max: 7000, avg: 3000, pr_count: 4 }
+	},
+	pull_requests: [],
+	pr_contributor_stats: [
+		{
+			author: 'alice',
+			prs_by_date: { '2025-12-22': 1, '2025-12-23': 0 },
+			prs: [],
+			avg_days_to_merge: 2,
+			avg_review_comments: 1,
+			total_prs: 1
+		},
+		{
+			author: 'manager',
+			prs_by_date: { '2025-12-22': 2, '2025-12-23': 1 },
+			prs: [],
+			avg_days_to_merge: 5,
+			avg_review_comments: 0,
+			total_prs: 3
+		}
+	],
+	reviewer_stats: {
+		alice: {
+			reviewer: 'alice',
+			total_prs_reviewed: 4,
+			total_review_comments: 8,
+			avg_comments_per_pr: 2
+		},
+		bob: {
+			reviewer: 'bob',
+			total_prs_reviewed: 2,
+			total_review_comments: 2,
+			avg_comments_per_pr: 1
+		}
+	},
+	review_comments: [],
+	...overrides
+});
+
+const empty_hidden = (overrides: Partial<IDeveloperVisibility> = {}): IDeveloperVisibility => ({
+	reviews: [],
+	pr_sizes: [],
+	contributor_stats: [],
+	last_modified: null,
+	...overrides
+});
+
+describe('apply_visibility_filter', () => {
+	it('returns the data unchanged when nothing is hidden', () => {
+		const data = make_data();
+		const result = apply_visibility_filter(data, empty_hidden());
+
+		expect(Object.keys(result.data)).toEqual(['alice', 'bob']);
+		expect(Object.keys(result.pr_sizes)).toEqual(['alice', 'manager']);
+		expect(result.pr_contributor_stats.map((s) => s.author)).toEqual(['alice', 'manager']);
+		expect(Object.keys(result.reviewer_stats)).toEqual(['alice', 'bob']);
+	});
+
+	it('removes a hidden reviewer from the reviews grid and reviewer stats only', () => {
+		const data = make_data();
+		const result = apply_visibility_filter(data, empty_hidden({ reviews: ['bob'] }));
+
+		expect(Object.keys(result.data)).toEqual(['alice']);
+		expect(Object.keys(result.reviewer_stats)).toEqual(['alice']);
+		// Author-role sections untouched
+		expect(Object.keys(result.pr_sizes)).toEqual(['alice', 'manager']);
+		expect(result.pr_contributor_stats.map((s) => s.author)).toEqual(['alice', 'manager']);
+	});
+
+	it('removes a hidden author from PR sizes only', () => {
+		const data = make_data();
+		const result = apply_visibility_filter(data, empty_hidden({ pr_sizes: ['manager'] }));
+
+		expect(Object.keys(result.pr_sizes)).toEqual(['alice']);
+		// Other sections untouched
+		expect(result.pr_contributor_stats.map((s) => s.author)).toEqual(['alice', 'manager']);
+		expect(Object.keys(result.data)).toEqual(['alice', 'bob']);
+	});
+
+	it('removes a hidden author from contributor stats only', () => {
+		const data = make_data();
+		const result = apply_visibility_filter(data, empty_hidden({ contributor_stats: ['manager'] }));
+
+		expect(result.pr_contributor_stats.map((s) => s.author)).toEqual(['alice']);
+		// PR sizes for the manager still present (independent toggle)
+		expect(Object.keys(result.pr_sizes)).toEqual(['alice', 'manager']);
+	});
+
+	it('applies independent toggles for the same developer across sections', () => {
+		const data = make_data();
+		const result = apply_visibility_filter(
+			data,
+			empty_hidden({ pr_sizes: ['manager'], contributor_stats: ['manager'] })
+		);
+
+		expect(Object.keys(result.pr_sizes)).toEqual(['alice']);
+		expect(result.pr_contributor_stats.map((s) => s.author)).toEqual(['alice']);
+	});
+
+	it('does not mutate the input data', () => {
+		const data = make_data();
+		apply_visibility_filter(data, empty_hidden({ reviews: ['bob'], pr_sizes: ['manager'] }));
+
+		expect(Object.keys(data.data)).toEqual(['alice', 'bob']);
+		expect(Object.keys(data.pr_sizes)).toEqual(['alice', 'manager']);
+		expect(data.pr_contributor_stats.map((s) => s.author)).toEqual(['alice', 'manager']);
+	});
+});
+
+describe('list_dashboard_developers', () => {
+	it('returns the sorted union of developers with their section membership', () => {
+		const developers = list_dashboard_developers(make_data());
+
+		expect(developers.map((d) => d.login)).toEqual(['alice', 'bob', 'manager']);
+
+		const alice = developers.find((d) => d.login === 'alice')!;
+		expect(alice).toMatchObject({
+			in_reviews: true,
+			in_pr_sizes: true,
+			in_contributor_stats: true
+		});
+
+		const bob = developers.find((d) => d.login === 'bob')!;
+		expect(bob).toMatchObject({
+			in_reviews: true,
+			in_pr_sizes: false,
+			in_contributor_stats: false
+		});
+
+		const manager = developers.find((d) => d.login === 'manager')!;
+		expect(manager).toMatchObject({
+			in_reviews: false,
+			in_pr_sizes: true,
+			in_contributor_stats: true
+		});
+	});
+
+	it('treats reviewer-stats-only developers as appearing in reviews', () => {
+		const data = make_data({
+			data: {},
+			reviewer_stats: {
+				carol: {
+					reviewer: 'carol',
+					total_prs_reviewed: 1,
+					total_review_comments: 1,
+					avg_comments_per_pr: 1
+				}
+			}
+		});
+
+		const carol = list_dashboard_developers(data).find((d) => d.login === 'carol')!;
+		expect(carol.in_reviews).toBe(true);
+	});
+});
+
+describe('DeveloperVisibilityService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates and returns a default file when none exists', async () => {
+		vi.mocked(fs.existsSync).mockReturnValue(false);
+		const write_spy = vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+
+		const service = new DeveloperVisibilityService();
+		const result = await service.get_hidden();
+
+		expect(result).toEqual({
+			reviews: [],
+			pr_sizes: [],
+			contributor_stats: [],
+			last_modified: null
+		});
+		expect(write_spy).toHaveBeenCalledOnce();
+	});
+
+	it('reads and normalizes an existing file', async () => {
+		vi.mocked(fs.existsSync).mockReturnValue(true);
+		vi.mocked(fs.readFileSync).mockReturnValue(
+			JSON.stringify({
+				reviews: ['bob', 'bob'],
+				pr_sizes: ['manager'],
+				contributor_stats: [],
+				last_modified: '2025-12-23T00:00:00.000Z'
+			})
+		);
+
+		const service = new DeveloperVisibilityService();
+		const result = await service.get_hidden();
+
+		// De-dupes
+		expect(result.reviews).toEqual(['bob']);
+		expect(result.pr_sizes).toEqual(['manager']);
+		expect(result.last_modified).toBe('2025-12-23T00:00:00.000Z');
+	});
+
+	it('persists the full object and stamps last_modified on set_hidden', async () => {
+		const write_spy = vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+
+		const service = new DeveloperVisibilityService();
+		const result = await service.set_hidden({ reviews: ['bob'], pr_sizes: ['manager'] });
+
+		expect(result.reviews).toEqual(['bob']);
+		expect(result.pr_sizes).toEqual(['manager']);
+		expect(result.contributor_stats).toEqual([]);
+		expect(result.last_modified).not.toBeNull();
+
+		const written = JSON.parse(vi.mocked(write_spy).mock.calls[0][1] as string);
+		expect(written.reviews).toEqual(['bob']);
+	});
+
+	it('ignores non-string values when normalizing', async () => {
+		vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+
+		const service = new DeveloperVisibilityService();
+		// @ts-expect-error testing runtime hardening against bad input
+		const result = await service.set_hidden({ reviews: ['bob', 42, null] });
+
+		expect(result.reviews).toEqual(['bob']);
+	});
+});

--- a/src/lib/services/developer-visibility.test.ts
+++ b/src/lib/services/developer-visibility.test.ts
@@ -125,6 +125,15 @@ describe('apply_visibility_filter', () => {
 		expect(Object.keys(data.pr_sizes)).toEqual(['alice', 'manager']);
 		expect(data.pr_contributor_stats.map((s) => s.author)).toEqual(['alice', 'manager']);
 	});
+
+	it('shallow-filters: surviving values keep their original references', () => {
+		const data = make_data();
+		const result = apply_visibility_filter(data, empty_hidden({ reviews: ['bob'] }));
+
+		expect(result.reviewer_stats['alice']).toBe(data.reviewer_stats['alice']);
+		expect(result.pr_sizes['alice']).toBe(data.pr_sizes['alice']);
+		expect(result.pr_contributor_stats[0]).toBe(data.pr_contributor_stats[0]);
+	});
 });
 
 describe('list_dashboard_developers', () => {

--- a/src/lib/services/developer-visibility.ts
+++ b/src/lib/services/developer-visibility.ts
@@ -1,0 +1,139 @@
+import fs from 'fs';
+import { Logger } from './logger';
+import type { ICodeReviewsData, IDeveloperVisibility } from '../../types';
+
+export type VisibilitySection = 'reviews' | 'pr_sizes' | 'contributor_stats';
+
+const SECTIONS: VisibilitySection[] = ['reviews', 'pr_sizes', 'contributor_stats'];
+
+export class DeveloperVisibilityService {
+	private file_name = 'hidden-developers.json';
+
+	public async get_hidden(): Promise<IDeveloperVisibility> {
+		try {
+			if (fs.existsSync(this.file_name)) {
+				const data = JSON.parse(fs.readFileSync(this.file_name, 'utf8'));
+				return this.normalize(data);
+			} else {
+				const initial_data = this.empty();
+				fs.writeFileSync(this.file_name, JSON.stringify(initial_data));
+				return initial_data;
+			}
+		} catch (error: unknown) {
+			Logger.error(error);
+			throw error;
+		}
+	}
+
+	public async set_hidden(data: Partial<IDeveloperVisibility>): Promise<IDeveloperVisibility> {
+		try {
+			const normalized = this.normalize(data);
+			normalized.last_modified = new Date().toISOString();
+			fs.writeFileSync(this.file_name, JSON.stringify(normalized));
+			return normalized;
+		} catch (error: unknown) {
+			Logger.error(error);
+			throw error;
+		}
+	}
+
+	private empty(): IDeveloperVisibility {
+		return {
+			reviews: [],
+			pr_sizes: [],
+			contributor_stats: [],
+			last_modified: null
+		};
+	}
+
+	private normalize(data: Partial<IDeveloperVisibility> | null): IDeveloperVisibility {
+		const result = this.empty();
+		if (!data) return result;
+
+		for (const section of SECTIONS) {
+			const value = data[section];
+			if (Array.isArray(value)) {
+				// De-dupe and keep only strings
+				result[section] = [...new Set(value.filter((v): v is string => typeof v === 'string'))];
+			}
+		}
+
+		if (typeof data.last_modified === 'string') {
+			result.last_modified = data.last_modified;
+		}
+
+		return result;
+	}
+}
+
+/**
+ * Returns a copy of the synced code-review data with hidden developers stripped
+ * from each dashboard section. Pure function — does not mutate its inputs.
+ *
+ * - `hidden.reviews` removes reviewers from the Code Reviews grid (`data` and
+ *   `reviewer_stats`).
+ * - `hidden.pr_sizes` removes authors from the Average PR Size table (`pr_sizes`).
+ * - `hidden.contributor_stats` removes authors from the Contributor Statistics
+ *   section (`pr_contributor_stats`).
+ */
+export const apply_visibility_filter = (
+	data: ICodeReviewsData,
+	hidden: IDeveloperVisibility
+): ICodeReviewsData => {
+	const hidden_reviews = new Set(hidden.reviews);
+	const hidden_pr_sizes = new Set(hidden.pr_sizes);
+	const hidden_contributor_stats = new Set(hidden.contributor_stats);
+
+	const filter_record = <T>(
+		record: Record<string, T>,
+		hidden_set: Set<string>
+	): Record<string, T> => {
+		return Object.fromEntries(
+			Object.entries(record ?? {}).filter(([login]) => !hidden_set.has(login))
+		);
+	};
+
+	return {
+		...data,
+		data: filter_record(data.data, hidden_reviews),
+		reviewer_stats: filter_record(data.reviewer_stats, hidden_reviews),
+		pr_sizes: filter_record(data.pr_sizes, hidden_pr_sizes),
+		pr_contributor_stats: (data.pr_contributor_stats ?? []).filter(
+			(stats) => !hidden_contributor_stats.has(stats.author)
+		)
+	};
+};
+
+/**
+ * Builds the list of developers known to the dashboard, noting which sections
+ * each appears in. Used to render the settings page checkboxes.
+ */
+export const list_dashboard_developers = (
+	data: ICodeReviewsData
+): {
+	login: string;
+	in_reviews: boolean;
+	in_pr_sizes: boolean;
+	in_contributor_stats: boolean;
+}[] => {
+	const reviews = new Set(Object.keys(data.data ?? {}));
+	const reviewer_stats = new Set(Object.keys(data.reviewer_stats ?? {}));
+	const pr_sizes = new Set(Object.keys(data.pr_sizes ?? {}));
+	const contributor_stats = new Set((data.pr_contributor_stats ?? []).map((stats) => stats.author));
+
+	const all_logins = new Set<string>([
+		...reviews,
+		...reviewer_stats,
+		...pr_sizes,
+		...contributor_stats
+	]);
+
+	return [...all_logins]
+		.sort((a, b) => a.localeCompare(b))
+		.map((login) => ({
+			login,
+			in_reviews: reviews.has(login) || reviewer_stats.has(login),
+			in_pr_sizes: pr_sizes.has(login),
+			in_contributor_stats: contributor_stats.has(login)
+		}));
+};

--- a/src/lib/services/developer-visibility.ts
+++ b/src/lib/services/developer-visibility.ts
@@ -7,6 +7,8 @@ export type VisibilitySection = 'reviews' | 'pr_sizes' | 'contributor_stats';
 const SECTIONS: VisibilitySection[] = ['reviews', 'pr_sizes', 'contributor_stats'];
 
 export class DeveloperVisibilityService {
+	// Resolved relative to process.cwd() — the server must run from the project
+	// root, matching ExclusionsService and CodeReviewsService.
 	private file_name = 'hidden-developers.json';
 
 	public async get_hidden(): Promise<IDeveloperVisibility> {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,6 +22,7 @@
 		<Link href="/" kind="neutral-text">Dashboard</Link>
 		<Link href="/contributors" kind="neutral-text">Contributors</Link>
 		<Link href="/comments" kind="neutral-text">Comments</Link>
+		<Link href="/settings" kind="neutral-text">Settings</Link>
 	</nav>
 </header>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,16 +37,30 @@
 		parse_data(data);
 	});
 
+	const to_date_columns = (date_keys: string[]): Date[] =>
+		date_keys.map((date) => ({
+			date: dayjs(date).format('MMM DD'),
+			is_weekend: dayjs(date).day() === 0 || dayjs(date).day() === 6
+		}));
+
+	// Derive the date column headers from a stable source so they survive even
+	// when every reviewer is hidden (which empties `data.data`). Falls back to
+	// the contributor stats, which carry the same date range.
+	const get_date_keys = (data: ICodeReviewsData): string[] => {
+		const first_reviewer = Object.values(data.data)[0];
+		if (first_reviewer) return Object.keys(first_reviewer);
+
+		const first_contributor = data.pr_contributor_stats?.[0];
+		if (first_contributor) return Object.keys(first_contributor.prs_by_date);
+
+		return [];
+	};
+
 	const parse_data = (data: ICodeReviewsData) => {
 		last_synced = data.last_synced;
-		user_data = Object.entries(data.data).map(([user, reviews], index) => {
-			if (index === 0) {
-				dates = Object.keys(reviews).map((date) => ({
-					date: dayjs(date).format('MMM DD'),
-					is_weekend: dayjs(date).day() === 0 || dayjs(date).day() === 6
-				}));
-			}
+		dates = to_date_columns(get_date_keys(data));
 
+		user_data = Object.entries(data.data).map(([user, reviews]) => {
 			return {
 				user,
 				reviews: Object.entries(reviews).map(([date, count]) => ({

--- a/src/routes/api/github/developer-visibility/+server.ts
+++ b/src/routes/api/github/developer-visibility/+server.ts
@@ -1,0 +1,50 @@
+import { DeveloperVisibilityService } from '$lib/services/developer-visibility';
+import { ApiError } from '$lib/utils/api-error';
+import { ApiResponse } from '$lib/utils/api-response';
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+	try {
+		const visibility_service = new DeveloperVisibilityService();
+		const data = await visibility_service.get_hidden();
+
+		return json(data);
+	} catch (err: unknown) {
+		const response = new ApiResponse({ errors: ApiError.parse(err) });
+		return error(
+			response.status_code,
+			response.errors?.[0]?.message || 'An unknown error occurred'
+		);
+	}
+};
+
+export const PUT: RequestHandler = async ({ request }) => {
+	try {
+		const body = await request.json();
+
+		const is_string_array = (value: unknown): value is string[] =>
+			Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+		for (const section of ['reviews', 'pr_sizes', 'contributor_stats'] as const) {
+			if (body[section] !== undefined && !is_string_array(body[section])) {
+				return error(400, `${section} must be an array of strings`);
+			}
+		}
+
+		const visibility_service = new DeveloperVisibilityService();
+		const data = await visibility_service.set_hidden({
+			reviews: body.reviews,
+			pr_sizes: body.pr_sizes,
+			contributor_stats: body.contributor_stats
+		});
+
+		return json(data);
+	} catch (err: unknown) {
+		const response = new ApiResponse({ errors: ApiError.parse(err) });
+		return error(
+			response.status_code,
+			response.errors?.[0]?.message || 'An unknown error occurred'
+		);
+	}
+};

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -3,7 +3,7 @@ import type { PageServerLoad } from './$types';
 import { CodeReviewsService } from '$lib/services/code-reviews';
 import {
 	DeveloperVisibilityService,
-	apply_visibility_filter
+	list_dashboard_developers
 } from '$lib/services/developer-visibility';
 import { ApiError } from '$lib/utils/api-error';
 import { ApiResponse } from '$lib/utils/api-response';
@@ -16,7 +16,12 @@ export const load: PageServerLoad = async () => {
 		const sync_data = await code_review_service.get_synced_data();
 		const hidden = await visibility_service.get_hidden();
 
-		return apply_visibility_filter(sync_data, hidden);
+		return {
+			developers: list_dashboard_developers(sync_data),
+			hidden,
+			status: sync_data.status,
+			last_synced: sync_data.last_synced
+		};
 	} catch (err: unknown) {
 		const response = new ApiResponse({ errors: ApiError.parse(err) });
 		return error(

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,0 +1,309 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import Button from '$lib/components/Button.svelte';
+	import Link from '$lib/components/Link.svelte';
+	import dayjs from 'dayjs';
+
+	type ColumnKey = 'reviews' | 'pr_sizes' | 'contributor_stats';
+
+	type Developer = {
+		login: string;
+		in_reviews: boolean;
+		in_pr_sizes: boolean;
+		in_contributor_stats: boolean;
+	};
+
+	let { data }: { data: PageData } = $props();
+
+	const columns: { key: ColumnKey; label: string; applies: (dev: Developer) => boolean }[] = [
+		{ key: 'reviews', label: 'Reviews', applies: (dev) => dev.in_reviews },
+		{ key: 'pr_sizes', label: 'PR Sizes', applies: (dev) => dev.in_pr_sizes },
+		{
+			key: 'contributor_stats',
+			label: 'Contributor Stats',
+			applies: (dev) => dev.in_contributor_stats
+		}
+	];
+
+	let developers = $state<Developer[]>(data.developers ?? []);
+	let hidden = $state<Record<ColumnKey, Set<string>>>({
+		reviews: new Set(data.hidden.reviews),
+		pr_sizes: new Set(data.hidden.pr_sizes),
+		contributor_stats: new Set(data.hidden.contributor_stats)
+	});
+
+	let save_error = $state('');
+
+	const is_shown = (column: ColumnKey, login: string): boolean => !hidden[column].has(login);
+
+	const persist = async () => {
+		try {
+			save_error = '';
+			const response = await fetch('/api/github/developer-visibility', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					reviews: [...hidden.reviews],
+					pr_sizes: [...hidden.pr_sizes],
+					contributor_stats: [...hidden.contributor_stats]
+				})
+			});
+
+			if (!response.ok) {
+				const error = await response.json();
+				throw new Error(error.message ?? 'Failed to save changes');
+			}
+		} catch (err: unknown) {
+			save_error = err instanceof Error ? err.message : 'Failed to save changes';
+		}
+	};
+
+	const toggle = (column: ColumnKey, login: string) => {
+		if (hidden[column].has(login)) {
+			hidden[column].delete(login);
+		} else {
+			hidden[column].add(login);
+		}
+		hidden = { ...hidden, [column]: new Set(hidden[column]) };
+		persist();
+	};
+
+	const show_all = (column: ColumnKey) => {
+		hidden = { ...hidden, [column]: new Set() };
+		persist();
+	};
+
+	const hide_all = (column: ColumnKey) => {
+		const next = new Set(hidden[column]);
+		for (const dev of developers) {
+			if (columns.find((col) => col.key === column)!.applies(dev)) {
+				next.add(dev.login);
+			}
+		}
+		hidden = { ...hidden, [column]: next };
+		persist();
+	};
+</script>
+
+<div class="settings-page">
+	<header>
+		<div class="header-content">
+			<h1>Settings</h1>
+			<p class="last-synced">
+				Last synced: {data.last_synced
+					? dayjs(data.last_synced).format('MMM DD, YYYY hh:mm A')
+					: '--'}
+			</p>
+		</div>
+
+		<Link href="/" kind="secondary-text">Back to Dashboard</Link>
+	</header>
+
+	<section class="intro">
+		<h2>Developer Visibility</h2>
+		<p class="section-description">
+			Choose which developers appear in each section of the dashboard. Checked means shown. Changes
+			save automatically and apply the next time the dashboard loads. This only affects the
+			dashboard &mdash; the Contributors and Comments pages still show everyone.
+		</p>
+		{#if save_error}
+			<p class="save-error">{save_error}</p>
+		{/if}
+	</section>
+
+	{#if data.status === 'not-synced'}
+		<div class="empty-container">
+			<p>No developer data available. Please sync from the Dashboard first.</p>
+			<Link href="/" kind="primary">Go to Dashboard</Link>
+		</div>
+	{:else if developers.length === 0}
+		<div class="empty-container">
+			<p>No developers found in the last 14 days.</p>
+		</div>
+	{:else}
+		<div class="visibility-table">
+			<div class="visibility-header visibility-row">
+				<div class="dev-name">Developer</div>
+				{#each columns as column (column.key)}
+					<div class="column-head">
+						<span class="column-label">{column.label}</span>
+						<span class="column-actions">
+							<Button kind="neutral-text" onclick={() => show_all(column.key)}>Show all</Button>
+							<span class="divider">|</span>
+							<Button kind="neutral-text" onclick={() => hide_all(column.key)}>Hide all</Button>
+						</span>
+					</div>
+				{/each}
+			</div>
+
+			{#each developers as dev (dev.login)}
+				<div class="visibility-row">
+					<div class="dev-name">{dev.login}</div>
+					{#each columns as column (column.key)}
+						<div class="cell">
+							{#if column.applies(dev)}
+								<label class="visibility-checkbox">
+									<input
+										type="checkbox"
+										checked={is_shown(column.key, dev.login)}
+										onchange={() => toggle(column.key, dev.login)}
+									/>
+									<span class="checkbox-label">Show</span>
+								</label>
+							{:else}
+								<span class="not-applicable" title="No {column.label.toLowerCase()} data"
+									>&mdash;</span
+								>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.settings-page {
+		padding: 2rem;
+		max-width: 1000px;
+		margin: 0 auto;
+	}
+
+	header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		margin-bottom: 2rem;
+		flex-wrap: wrap;
+		gap: 1rem;
+	}
+
+	.header-content {
+		& h1 {
+			margin: 0 0 0.5rem 0;
+			color: var(--primary-500);
+		}
+
+		& .last-synced {
+			margin: 0;
+			font-size: 0.8rem;
+			color: var(--neutral-500);
+		}
+	}
+
+	.intro {
+		margin-bottom: 1.5rem;
+
+		& h2 {
+			font-size: 1.25rem;
+			color: var(--secondary-500);
+			margin: 0 0 0.5rem 0;
+		}
+
+		& .section-description {
+			font-size: 0.85rem;
+			color: var(--neutral-500);
+			margin: 0;
+			max-width: 60rem;
+		}
+
+		& .save-error {
+			margin: 0.75rem 0 0 0;
+			font-size: 0.85rem;
+			color: var(--danger-500);
+		}
+	}
+
+	.empty-container {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		gap: 1rem;
+		margin-top: 10vh;
+		text-align: center;
+	}
+
+	.visibility-table {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+	}
+
+	.visibility-row {
+		display: grid;
+		grid-template-columns: 16rem repeat(3, 1fr);
+		grid-column-gap: 0.5rem;
+		align-items: center;
+		border-bottom: 1px solid var(--neutral-200);
+		padding: 0.5rem 0;
+	}
+
+	.visibility-header {
+		align-items: end;
+
+		& .dev-name {
+			color: var(--secondary-500);
+		}
+	}
+
+	.column-head {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.25rem;
+		text-align: center;
+
+		& .column-label {
+			color: var(--secondary-500);
+			font-weight: 500;
+		}
+
+		& .column-actions {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			font-size: 0.75rem;
+		}
+
+		& .divider {
+			color: var(--neutral-300);
+		}
+	}
+
+	.dev-name {
+		font-weight: 500;
+		color: var(--neutral-800);
+		word-break: break-word;
+	}
+
+	.cell {
+		display: flex;
+		justify-content: center;
+	}
+
+	.visibility-checkbox {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		cursor: pointer;
+
+		& input[type='checkbox'] {
+			width: 1rem;
+			height: 1rem;
+			cursor: pointer;
+			accent-color: var(--primary-500);
+		}
+
+		& .checkbox-label {
+			font-size: 0.75rem;
+			color: var(--neutral-600);
+		}
+	}
+
+	.not-applicable {
+		color: var(--neutral-300);
+		font-size: 0.85rem;
+	}
+</style>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -2,6 +2,7 @@
 	import type { PageData } from './$types';
 	import Button from '$lib/components/Button.svelte';
 	import Link from '$lib/components/Link.svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import dayjs from 'dayjs';
 
 	type ColumnKey = 'reviews' | 'pr_sizes' | 'contributor_stats';
@@ -33,15 +34,22 @@
 	});
 
 	let save_error = $state('');
+	let abort_controller: AbortController | null = null;
 
 	const is_shown = (column: ColumnKey, login: string): boolean => !hidden[column].has(login);
 
 	const persist = async () => {
+		// Cancel any in-flight save so a slower earlier request can't land after a
+		// newer one and overwrite the latest state on disk.
+		abort_controller?.abort();
+		abort_controller = new AbortController();
+
 		try {
 			save_error = '';
 			const response = await fetch('/api/github/developer-visibility', {
 				method: 'PUT',
 				headers: { 'Content-Type': 'application/json' },
+				signal: abort_controller.signal,
 				body: JSON.stringify({
 					reviews: [...hidden.reviews],
 					pr_sizes: [...hidden.pr_sizes],
@@ -54,6 +62,8 @@
 				throw new Error(error.message ?? 'Failed to save changes');
 			}
 		} catch (err: unknown) {
+			// A superseded request was intentionally aborted — not a real failure.
+			if (err instanceof DOMException && err.name === 'AbortError') return;
 			save_error = err instanceof Error ? err.message : 'Failed to save changes';
 		}
 	};
@@ -114,6 +124,16 @@
 	{#if data.status === 'not-synced'}
 		<div class="empty-container">
 			<p>No developer data available. Please sync from the Dashboard first.</p>
+			<Link href="/" kind="primary">Go to Dashboard</Link>
+		</div>
+	{:else if data.status === 'syncing'}
+		<div class="empty-container">
+			<Spinner size="large" type="tertiary">Syncing</Spinner>
+			<p>A sync is in progress. Developer data will be available once it completes.</p>
+		</div>
+	{:else if data.status === 'error'}
+		<div class="empty-container">
+			<p>A sync error occurred. Go to the Dashboard to retry before managing visibility.</p>
 			<Link href="/" kind="primary">Go to Dashboard</Link>
 		</div>
 	{:else if developers.length === 0}

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,13 @@ export interface IExcludedPRs {
 	last_modified: string | null;
 }
 
+export interface IDeveloperVisibility {
+	reviews: string[];
+	pr_sizes: string[];
+	contributor_stats: string[];
+	last_modified: string | null;
+}
+
 export interface ICodeReviewsData {
 	last_synced: string | null;
 	status: Status;


### PR DESCRIPTION
## Summary

Adds a **Settings** page (`/settings`) that lets you choose which developers' data appears in each section of the dashboard, via a checkbox grid. This addresses two problems with the dashboard showing every contributor who has ever touched the repo:

- Release-managers who only cut releases were polluting the **Average PR Size** table with huge outlier PRs.
- There was no way to show one person their own numbers without also exposing everyone else's.

### How it works
- **Pure, server-side display filter.** Hiding a developer never mutates `data.json` and needs no "recalculate" step — every dashboard stat is per-user and independent, so hiding one row can't distort anyone else's numbers. Filtering happens in the dashboard's `load`, so hidden data never reaches the browser.
- **Three independent toggles per developer**, mirroring the dashboard sections:
  - **Reviews** → Code Reviews grid + reviewer-stat columns
  - **PR Sizes** → Average PR Size table
  - **Contributor Stats** → Contributor summary, PRs-per-day, and PR detail accordions
- **Show-by-default.** Hidden logins are persisted per-section in `hidden-developers.json` (mirroring the existing `excluded-prs.json` pattern). New contributors and bots appear automatically until you hide them.
- **Auto-save**, with per-column **Show all / Hide all** buttons. Checked = shown.
- Scope is the dashboard (`/`) only — the Contributors and Comments pages still show everyone.

### Notable details
- Date column headers on the dashboard were previously derived from the first reviewer in the data; decoupled them to a stable source so hiding every reviewer can't blank the Contributor "PRs Opened Per Day" table.
- Filtering logic lives in pure, unit-tested helpers (`apply_visibility_filter`, `list_dashboard_developers`).

## Changes
- **New** `DeveloperVisibilityService` + pure helpers (`src/lib/services/developer-visibility.ts`)
- **New** API route `GET`/`PUT` `/api/github/developer-visibility`
- **New** `/settings` page (server load + UI)
- **New** `IDeveloperVisibility` type
- Dashboard `load` now applies the visibility filter; date headers decoupled
- **Settings** link added to the nav
- 12 new unit tests

## Manual testing
1. `npm run dev`, sync code reviews from the dashboard if not already synced.
2. Visit **Settings** in the nav. Confirm every dashboard developer is listed with three checkboxes (all checked = shown by default), and that bots like `coderabbitai[bot]` appear.
3. Uncheck a release-manager's **PR Sizes** box. Return to the dashboard → their row is gone from **Average PR Size**, but they still appear in Reviews and Contributor Stats.
4. On Settings, click **Hide all** under each column, then re-check one developer's boxes. Dashboard should now show only that person.
5. Verify `/contributors` and `/comments` still show everyone (scope is dashboard-only).
6. Hide every reviewer, return to dashboard → the Contributor "PRs Opened Per Day" date headers still render correctly.
7. Reload the app — selections persist (`hidden-developers.json`).

## Checks
- `npm run check` → 0 errors / 0 warnings
- `npm run lint` → clean (Prettier + ESLint)
- `npm run test:unit -- --run` → 16/16 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)