### PR TITLE
fix: exclude closed-unmerged PRs from all calculations

### DIFF
--- a/src/lib/services/code-reviews.test.ts
+++ b/src/lib/services/code-reviews.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { is_closed_unmerged } from './code-reviews';
+
+describe('is_closed_unmerged', () => {
+	it('returns true for a PR closed without being merged', () => {
+		expect(is_closed_unmerged({ state: 'closed', merged_at: null })).toBe(true);
+	});
+
+	it('returns false for a merged PR (closed with a merged_at timestamp)', () => {
+		expect(is_closed_unmerged({ state: 'closed', merged_at: '2026-05-01T00:00:00Z' })).toBe(false);
+	});
+
+	it('returns false for an open PR', () => {
+		expect(is_closed_unmerged({ state: 'open', merged_at: null })).toBe(false);
+	});
+
+	it('treats an empty-string merged_at as never merged', () => {
+		expect(is_closed_unmerged({ state: 'closed', merged_at: '' })).toBe(true);
+	});
+});

--- a/src/lib/services/code-reviews.ts
+++ b/src/lib/services/code-reviews.ts
@@ -19,6 +19,15 @@ type PullRequest = RestEndpointMethodTypes['pulls']['list']['response']['data'][
 type PullRequestDetail = RestEndpointMethodTypes['pulls']['get']['response']['data'];
 type Review = RestEndpointMethodTypes['pulls']['listReviews']['response']['data'][number];
 
+/**
+ * A PR closed without being merged. In GitHub's model a merged PR also has
+ * state 'closed' but carries a merged_at timestamp; one closed without merging
+ * has none. These were never merged and must not count toward any metric.
+ */
+export function is_closed_unmerged(pr: { state: string; merged_at: string | null }): boolean {
+	return pr.state === 'closed' && !pr.merged_at;
+}
+
 export class CodeReviewsService {
 	private file_name = 'data.json';
 	private numberOfDays = 14;
@@ -128,7 +137,8 @@ export class CodeReviewsService {
 			const { countMap: reviewCommentsMap, comments: review_comments } =
 				await this.fetch_review_comments_in_parallel(prDetails);
 
-			// Extract PR info for storage (all PRs, not filtered)
+			// Extract PR info for storage. prDetails excludes closed-unmerged PRs
+			// (filtered at fetch time); exclusion-list filtering happens per-metric.
 			const pull_requests = this.extract_pr_info(prDetails, reviewCommentsMap);
 
 			// Calculate stats with exclusions applied
@@ -247,6 +257,9 @@ export class CodeReviewsService {
 				continue;
 			}
 
+			// Skip PRs closed without being merged
+			if (is_closed_unmerged(pr)) continue;
+
 			// Skip excluded PRs
 			if (excludedPRs.has(pr.number)) {
 				console.log(`Skipping excluded PR #${pr.number} by ${author}`);
@@ -275,7 +288,7 @@ export class CodeReviewsService {
 
 		for (const pr of pullRequests) {
 			// Skip PRs closed without being merged
-			if (pr.state === 'closed' && !pr.merged_at) {
+			if (is_closed_unmerged(pr)) {
 				continue;
 			}
 
@@ -331,7 +344,7 @@ export class CodeReviewsService {
 			if (!author) continue;
 
 			// Skip PRs closed without being merged
-			if (pr.state === 'closed' && !pr.merged_at) continue;
+			if (is_closed_unmerged(pr)) continue;
 
 			// Skip excluded PRs
 			if (excludedPRs.has(pr.number)) continue;
@@ -456,10 +469,9 @@ export class CodeReviewsService {
 					break;
 				}
 
-				// Exclude PRs that were closed without being merged. A merged PR also
-				// has state 'closed' but carries a merged_at timestamp; one that was
-				// closed and never merged has none, and must not count toward any metric.
-				if (pr.state === 'closed' && !pr.merged_at) {
+				// Exclude PRs that were closed without being merged so they never
+				// enter any downstream metric, the stored list, or the UI.
+				if (is_closed_unmerged(pr)) {
 					continue;
 				}
 
@@ -689,6 +701,10 @@ export class CodeReviewsService {
 		for (const pr of prDetails) {
 			const author = pr.user?.login;
 			if (!author) continue;
+
+			// Skip PRs closed without being merged. prDetails already flows from a
+			// filtered list, but this keeps the invariant explicit at the call site.
+			if (is_closed_unmerged(pr)) continue;
 
 			// Skip excluded PRs
 			if (excludedPRs.has(pr.number)) continue;

--- a/src/lib/services/code-reviews.ts
+++ b/src/lib/services/code-reviews.ts
@@ -274,6 +274,11 @@ export class CodeReviewsService {
 		const prsByAuthor: Record<string, number[]> = {};
 
 		for (const pr of pullRequests) {
+			// Skip PRs closed without being merged
+			if (pr.state === 'closed' && !pr.merged_at) {
+				continue;
+			}
+
 			// Skip excluded PRs
 			if (excludedPRs.has(pr.number)) {
 				console.log(`Skipping excluded PR #${pr.number} by ${pr.author}`);
@@ -324,6 +329,9 @@ export class CodeReviewsService {
 		for (const pr of pullRequests) {
 			const author = pr.author;
 			if (!author) continue;
+
+			// Skip PRs closed without being merged
+			if (pr.state === 'closed' && !pr.merged_at) continue;
 
 			// Skip excluded PRs
 			if (excludedPRs.has(pr.number)) continue;
@@ -447,6 +455,14 @@ export class CodeReviewsService {
 					shouldStop = true;
 					break;
 				}
+
+				// Exclude PRs that were closed without being merged. A merged PR also
+				// has state 'closed' but carries a merged_at timestamp; one that was
+				// closed and never merged has none, and must not count toward any metric.
+				if (pr.state === 'closed' && !pr.merged_at) {
+					continue;
+				}
+
 				recentPRs.push(pr);
 			}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -273,13 +273,11 @@
 											</a>
 										</div>
 										<div class="pr-title" title={pr.title}>{pr.title}</div>
-										<div class:open={pr.state === 'open'} class:merged={pr.merged_at}>
+										<div class:open={!pr.merged_at} class:merged={pr.merged_at}>
 											{#if pr.merged_at}
 												merged
-											{:else if pr.state === 'open'}
-												open
 											{:else}
-												closed
+												open
 											{/if}
 										</div>
 										<div>{pr.days_to_merge !== null ? pr.days_to_merge : '-'}</div>


### PR DESCRIPTION
## Summary

PRs that were **closed without being merged** were being counted toward review metrics, PR sizes, and contributor stats. Closed PRs were never merged, so they should not factor into any calculation.

In GitHub's data model, a *merged* PR also has `state: 'closed'` but carries a `merged_at` timestamp; a PR closed without merging has `state === 'closed'` with `merged_at == null`. That precise condition is now filtered out — open and merged PRs are unaffected.

## Changes

- **`get_recent_pull_requests`** — the single fetch chokepoint feeding the entire `sync()` flow (PR details, review counts, reviewer stats, contributor stats, the stored `pull_requests` list). Excluding here means closed-unmerged PRs never enter any metric, never get stored, and never appear in the UI.
- **`calculate_pr_sizes_from_stored`** / **`calculate_pr_contributor_stats_from_stored`** — defensive guards on the recalculation paths (triggered when toggling contributor exclusions), so a `data.json` synced before this change also drops closed-unmerged PRs without a full re-sync.
- **`+page.svelte`** — pruned the now-unreachable `closed` branch in the PR state cell; only `merged` / `open` remain.

## Testing

- `npm run check` — 0 errors, 0 warnings
- `npm run test:unit` — 17/17 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)