### PR TITLE
Fix contributors page crash from duplicate PRs + make sections collapsible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ vite.config.ts.timestamp-*
 data.json
 excluded-prs.json
 hidden-developers.json
+# Playwright MCP debugging artifacts
+.playwright-mcp

--- a/src/lib/actions/accordion.svelte.test.ts
+++ b/src/lib/actions/accordion.svelte.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { accordion } from './accordion';
+
+/**
+ * Tests for the accordion action's open/close state machine.
+ *
+ * jsdom implements neither the Web Animations API (`Element.animate`) nor
+ * layout (`offsetHeight` is always 0), so both are stubbed. Stubbing `animate`
+ * to return a controllable handle lets us drive `onfinish` by hand and assert
+ * how the state machine settles, and stubbing `requestAnimationFrame` to run
+ * synchronously means `open()` -> `expand()` completes within the click.
+ */
+
+interface FakeAnimation {
+	cancel: ReturnType<typeof vi.fn>;
+	onfinish: (() => void) | null;
+	oncancel: (() => void) | null;
+}
+
+let animations: FakeAnimation[];
+
+function makeDetails({ withSummary = true, withContent = true } = {}): HTMLDetailsElement {
+	const el = document.createElement('details');
+	if (withSummary) {
+		const summary = document.createElement('summary');
+		summary.textContent = 'Title';
+		el.appendChild(summary);
+	}
+	if (withContent) {
+		const content = document.createElement('div');
+		content.className = 'content';
+		el.appendChild(content);
+	}
+	document.body.appendChild(el);
+	return el;
+}
+
+function clickSummary(el: HTMLDetailsElement): MouseEvent {
+	const event = new MouseEvent('click', { cancelable: true, bubbles: true });
+	el.querySelector('summary')!.dispatchEvent(event);
+	return event;
+}
+
+describe('accordion action', () => {
+	beforeEach(() => {
+		animations = [];
+		// jsdom does not implement the Web Animations API at all, so the property
+		// must be defined rather than spied (vi.spyOn requires it to already exist).
+		(Element.prototype as unknown as { animate: unknown }).animate = vi.fn(() => {
+			const anim: FakeAnimation = { cancel: vi.fn(), onfinish: null, oncancel: null };
+			animations.push(anim);
+			return anim as unknown as Animation;
+		});
+		// jsdom reports 0 for every layout measurement; give a stable non-zero size.
+		vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(50);
+		// Run the rAF callback inline so expand() executes during the click.
+		vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+			cb(0);
+			return 0;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete (Element.prototype as unknown as { animate?: unknown }).animate;
+		document.body.innerHTML = '';
+	});
+
+	it('suppresses the native toggle so the animation can drive open state', () => {
+		const el = makeDetails();
+		accordion(el);
+
+		const event = clickSummary(el);
+
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it('opens a closed details and keeps it open when the expand finishes', () => {
+		const el = makeDetails();
+		accordion(el);
+		expect(el.open).toBe(false);
+
+		clickSummary(el);
+
+		// open() flips `open` synchronously and starts one expand animation.
+		expect(el.open).toBe(true);
+		expect(animations).toHaveLength(1);
+
+		animations[0].onfinish!();
+
+		expect(el.open).toBe(true);
+		// Inline height/overflow set during the animation are cleared on finish.
+		expect(el.style.height).toBe('');
+		expect(el.style.overflow).toBe('');
+	});
+
+	it('closes an open details only once the shrink animation finishes', () => {
+		const el = makeDetails();
+		accordion(el);
+
+		clickSummary(el);
+		animations[0].onfinish!(); // settle open
+		expect(el.open).toBe(true);
+
+		clickSummary(el);
+
+		// Shrink is queued, but the element stays open until it completes.
+		expect(animations).toHaveLength(2);
+		expect(el.open).toBe(true);
+
+		animations[1].onfinish!();
+
+		expect(el.open).toBe(false);
+	});
+
+	it('cancels the in-flight animation when interrupted mid-expand', () => {
+		const el = makeDetails();
+		accordion(el);
+
+		clickSummary(el); // expand starts (animations[0]), not yet finished
+		clickSummary(el); // interrupt -> shrink
+
+		expect(animations[0].cancel).toHaveBeenCalled();
+		expect(animations).toHaveLength(2);
+	});
+
+	it('detaches the click handler on destroy', () => {
+		const el = makeDetails();
+		const handle = accordion(el);
+
+		handle!.destroy();
+		const event = clickSummary(el);
+
+		// Handler gone: native toggle is no longer prevented and nothing animates.
+		expect(event.defaultPrevented).toBe(false);
+		expect(animations).toHaveLength(0);
+	});
+
+	it('bails and logs when the .content element is missing', () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const el = makeDetails({ withContent: false });
+
+		const handle = accordion(el);
+
+		expect(handle).toBeUndefined();
+		expect(consoleError).toHaveBeenCalled();
+
+		clickSummary(el);
+		expect(animations).toHaveLength(0);
+	});
+
+	it('bails and logs when the summary element is missing', () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const el = makeDetails({ withSummary: false });
+
+		const handle = accordion(el);
+
+		expect(handle).toBeUndefined();
+		expect(consoleError).toHaveBeenCalled();
+	});
+});

--- a/src/lib/actions/accordion.ts
+++ b/src/lib/actions/accordion.ts
@@ -1,0 +1,101 @@
+/**
+ * Svelte action that animates the open/close of a native <details> element.
+ *
+ * <details> does not animate by default — it snaps open and shut. This wraps it
+ * with the Web Animations API to tween the element's height, following the
+ * technique from https://css-tricks.com/how-to-animate-the-details-element/.
+ *
+ * The element must contain a <summary> and a `.content` wrapper:
+ *
+ *   <details use:accordion>
+ *     <summary>Title</summary>
+ *     <div class="content">...</div>
+ *   </details>
+ *
+ * Applied per-element via `use:accordion`, so it composes with an {#each} list
+ * of independently collapsible sections.
+ */
+class Accordion {
+	private el: HTMLDetailsElement;
+	private summary: HTMLElement;
+	private content: HTMLElement;
+	private animation: Animation | null = null;
+	private isClosing = false;
+	private isExpanding = false;
+
+	constructor(el: HTMLDetailsElement) {
+		this.el = el;
+		this.summary = el.querySelector('summary')!;
+		this.content = el.querySelector('.content')!;
+		this.summary.addEventListener('click', this.onClick);
+	}
+
+	destroy = () => {
+		this.summary.removeEventListener('click', this.onClick);
+		this.animation?.cancel();
+	};
+
+	private onClick = (e: MouseEvent) => {
+		e.preventDefault();
+		this.el.style.overflow = 'hidden';
+
+		if (this.isClosing || !this.el.open) {
+			this.open();
+		} else if (this.isExpanding || this.el.open) {
+			this.shrink();
+		}
+	};
+
+	private shrink = () => {
+		this.isClosing = true;
+
+		const startHeight = `${this.el.offsetHeight}px`;
+		const endHeight = `${this.summary.offsetHeight}px`;
+
+		this.animation?.cancel();
+		this.animation = this.el.animate(
+			{ height: [startHeight, endHeight] },
+			{ duration: 300, easing: 'ease-in-out' }
+		);
+
+		this.animation.onfinish = () => this.onAnimationFinish(false);
+		this.animation.oncancel = () => (this.isClosing = false);
+	};
+
+	private open = () => {
+		this.el.style.height = `${this.el.offsetHeight}px`;
+		this.el.open = true;
+		window.requestAnimationFrame(this.expand);
+	};
+
+	private expand = () => {
+		this.isExpanding = true;
+
+		const startHeight = `${this.el.offsetHeight}px`;
+		const endHeight = `${this.summary.offsetHeight + this.content.offsetHeight}px`;
+
+		this.animation?.cancel();
+		this.animation = this.el.animate(
+			{ height: [startHeight, endHeight] },
+			{ duration: 400, easing: 'ease-out' }
+		);
+
+		this.animation.onfinish = () => this.onAnimationFinish(true);
+		this.animation.oncancel = () => (this.isExpanding = false);
+	};
+
+	private onAnimationFinish = (open: boolean) => {
+		this.el.open = open;
+		this.animation = null;
+		this.isClosing = false;
+		this.isExpanding = false;
+		this.el.style.height = this.el.style.overflow = '';
+	};
+}
+
+export function accordion(el: HTMLDetailsElement) {
+	const instance = new Accordion(el);
+	return {
+		destroy: instance.destroy
+	};
+}

--- a/src/lib/actions/accordion.ts
+++ b/src/lib/actions/accordion.ts
@@ -23,10 +23,10 @@ class Accordion {
 	private isClosing = false;
 	private isExpanding = false;
 
-	constructor(el: HTMLDetailsElement) {
+	constructor(el: HTMLDetailsElement, summary: HTMLElement, content: HTMLElement) {
 		this.el = el;
-		this.summary = el.querySelector('summary')!;
-		this.content = el.querySelector('.content')!;
+		this.summary = summary;
+		this.content = content;
 		this.summary.addEventListener('click', this.onClick);
 	}
 
@@ -94,7 +94,20 @@ class Accordion {
 }
 
 export function accordion(el: HTMLDetailsElement) {
-	const instance = new Accordion(el);
+	const summary = el.querySelector('summary');
+	const content = el.querySelector<HTMLElement>('.content');
+
+	// The animation measures the summary and content heights; without both there
+	// is nothing to animate. Bail loudly rather than throwing on the first click.
+	if (!summary || !content) {
+		console.error(
+			'accordion: <details> must contain a <summary> and a .content element; skipping animation.',
+			el
+		);
+		return;
+	}
+
+	const instance = new Accordion(el, summary, content);
 	return {
 		destroy: instance.destroy
 	};

--- a/src/lib/services/code-reviews.ts
+++ b/src/lib/services/code-reviews.ts
@@ -3,6 +3,7 @@ import { Octokit } from '@octokit/rest';
 import type { RestEndpointMethodTypes } from '@octokit/rest';
 import { Logger } from './logger';
 import { ExclusionsService } from './exclusions';
+import { dedupe_prs_by_number } from '$lib/utils/pull-requests';
 import { GITHUB_OWNER, GITHUB_REPO, GITHUB_TOKEN } from '$env/static/private';
 import { ApiError } from '$lib/utils/api-error';
 import type {
@@ -483,7 +484,9 @@ export class CodeReviewsService {
 			}
 		}
 
-		return recentPRs;
+		// Paginating a list sorted by updated_at can surface the same PR on two
+		// pages; dedupe so duplicates never reach storage or any calculation.
+		return dedupe_prs_by_number(recentPRs);
 	};
 
 	private fetch_reviews_in_parallel = async (pullRequests: PullRequest[]): Promise<Review[]> => {

--- a/src/lib/utils/pull-requests.test.ts
+++ b/src/lib/utils/pull-requests.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { dedupe_prs_by_number } from './pull-requests';
+
+describe('dedupe_prs_by_number', () => {
+	it('returns the list unchanged when there are no duplicates', () => {
+		const prs = [{ number: 1 }, { number: 2 }, { number: 3 }];
+		expect(dedupe_prs_by_number(prs)).toEqual([{ number: 1 }, { number: 2 }, { number: 3 }]);
+	});
+
+	it('removes duplicate PR numbers, keeping the first occurrence', () => {
+		const first = { number: 1376, title: 'fresh' };
+		const stale = { number: 1376, title: 'stale' };
+		const result = dedupe_prs_by_number([first, { number: 1377 }, stale]);
+		expect(result).toEqual([first, { number: 1377 }]);
+		// The first occurrence (freshest, since results are newest-updated first) wins.
+		expect(result[0]).toBe(first);
+	});
+
+	it('collapses several duplicates of the same number to one entry', () => {
+		const result = dedupe_prs_by_number([{ number: 5 }, { number: 5 }, { number: 5 }]);
+		expect(result).toEqual([{ number: 5 }]);
+	});
+
+	it('preserves the original ordering of distinct PRs', () => {
+		const prs = [{ number: 3 }, { number: 1 }, { number: 3 }, { number: 2 }];
+		expect(dedupe_prs_by_number(prs).map((p) => p.number)).toEqual([3, 1, 2]);
+	});
+
+	it('returns an empty array for empty input', () => {
+		expect(dedupe_prs_by_number([])).toEqual([]);
+	});
+});

--- a/src/lib/utils/pull-requests.ts
+++ b/src/lib/utils/pull-requests.ts
@@ -1,0 +1,23 @@
+/**
+ * Remove duplicate pull requests by PR number, keeping the first occurrence.
+ *
+ * GitHub's `pulls.list` is paginated and sorted by `updated` descending. A PR
+ * that is updated while we page through the results can shift between pages and
+ * be returned twice. Left unchecked these duplicates inflate every downstream
+ * metric (sizes, contributor and reviewer stats all count the PR twice) and
+ * crash the contributors page, whose keyed `{#each}` rejects a repeated key.
+ * The first occurrence is the freshest (results are newest-updated first).
+ *
+ * Pure and dependency-free so it is safe to import from both server services
+ * and client components.
+ */
+export function dedupe_prs_by_number<T extends { number: number }>(prs: T[]): T[] {
+	const seen = new Set<number>();
+	const unique: T[] = [];
+	for (const pr of prs) {
+		if (seen.has(pr.number)) continue;
+		seen.add(pr.number);
+		unique.push(pr);
+	}
+	return unique;
+}

--- a/src/routes/contributors/+page.svelte
+++ b/src/routes/contributors/+page.svelte
@@ -6,6 +6,7 @@
 	import Spinner from '$lib/components/Spinner.svelte';
 	import dayjs from 'dayjs';
 	import { dedupe_prs_by_number } from '$lib/utils/pull-requests';
+	import { accordion } from '$lib/actions/accordion';
 	import type { IPullRequestInfo } from '../../types';
 
 	let { data }: { data: PageData } = $props();
@@ -123,44 +124,67 @@
 			{/if}
 
 			{#each get_sorted_authors() as author (author)}
-				<section class="contributor-section">
-					<h2>
-						{author}
-						<span class="pr-count">({pr_groups[author].length} PRs)</span>
-					</h2>
+				<details class="contributor-section" use:accordion>
+					<summary>
+						<span class="summary-label">
+							{author}
+							<span class="pr-count">({pr_groups[author].length} PRs)</span>
+						</span>
+						<svg
+							class="chevron"
+							width="16"
+							height="16"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<polyline points="6 9 12 15 18 9" />
+						</svg>
+					</summary>
 
-					<div class="pr-list">
-						{#each pr_groups[author] as pr (pr.number)}
-							<div
-								class="pr-item"
-								class:excluded={excluded.has(pr.number)}
-								class:large-pr={pr.additions + pr.deletions > 1000}
-							>
-								<label class="pr-checkbox">
-									<input
-										type="checkbox"
-										checked={excluded.has(pr.number)}
-										onchange={() => toggle_exclusion(pr.number)}
-									/>
-									<span class="checkbox-label">Exclude</span>
-								</label>
+					<div class="content">
+						<div class="pr-list">
+							{#each pr_groups[author] as pr (pr.number)}
+								<div
+									class="pr-item"
+									class:excluded={excluded.has(pr.number)}
+									class:large-pr={pr.additions + pr.deletions > 1000}
+								>
+									<label class="pr-checkbox">
+										<input
+											type="checkbox"
+											checked={excluded.has(pr.number)}
+											onchange={() => toggle_exclusion(pr.number)}
+										/>
+										<span class="checkbox-label">Exclude</span>
+									</label>
 
-								<div class="pr-info">
-									<a href={pr.html_url} target="_blank" rel="noopener noreferrer" class="pr-title">
-										#{pr.number} - {pr.title}
-									</a>
-									<div class="pr-meta">
-										<span class="pr-size"
-											>{(pr.additions + pr.deletions).toLocaleString()} lines</span
+									<div class="pr-info">
+										<a
+											href={pr.html_url}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="pr-title"
 										>
-										<span class="pr-additions">+{pr.additions.toLocaleString()}</span>
-										<span class="pr-deletions">-{pr.deletions.toLocaleString()}</span>
+											#{pr.number} - {pr.title}
+										</a>
+										<div class="pr-meta">
+											<span class="pr-size"
+												>{(pr.additions + pr.deletions).toLocaleString()} lines</span
+											>
+											<span class="pr-additions">+{pr.additions.toLocaleString()}</span>
+											<span class="pr-deletions">-{pr.deletions.toLocaleString()}</span>
+										</div>
 									</div>
 								</div>
-							</div>
-						{/each}
+							{/each}
+						</div>
 					</div>
-				</section>
+				</details>
 			{/each}
 		</div>
 	{/if}
@@ -243,21 +267,58 @@
 		background-color: var(--neutral-50);
 		border: 1px solid var(--neutral-200);
 		border-radius: 0.5rem;
-		padding: 1.5rem;
+		/* Clip children to the rounded corners during the height animation. The
+		   accordion action measures summary + content height, so padding lives on
+		   those children rather than on the <details> itself. */
+		overflow: hidden;
 
-		& h2 {
-			margin: 0 0 1rem 0;
-			font-size: 1.1rem;
-			color: var(--neutral-800);
+		& summary {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 0.5rem;
+			padding: 1.25rem 1.5rem;
+			cursor: pointer;
+			user-select: none;
+			/* Remove the native disclosure triangle in favour of the chevron. */
+			list-style: none;
+
+			&::-webkit-details-marker {
+				display: none;
+			}
+
+			&:hover {
+				background-color: var(--neutral-100);
+			}
+		}
+
+		& .summary-label {
 			display: flex;
 			align-items: baseline;
 			gap: 0.5rem;
+			font-size: 1.1rem;
+			font-weight: 600;
+			color: var(--neutral-800);
 		}
 
 		& .pr-count {
 			font-size: 0.85rem;
 			font-weight: normal;
 			color: var(--neutral-500);
+		}
+
+		& .chevron {
+			flex-shrink: 0;
+			color: var(--neutral-500);
+			transition: transform 0.2s ease;
+		}
+
+		&[open] .chevron {
+			transform: rotate(180deg);
+		}
+
+		& .content {
+			padding: 0 1.5rem 1.5rem;
 		}
 	}
 

--- a/src/routes/contributors/+page.svelte
+++ b/src/routes/contributors/+page.svelte
@@ -5,6 +5,7 @@
 	import Link from '$lib/components/Link.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
 	import dayjs from 'dayjs';
+	import { dedupe_prs_by_number } from '$lib/utils/pull-requests';
 	import type { IPullRequestInfo } from '../../types';
 
 	let { data }: { data: PageData } = $props();
@@ -23,7 +24,10 @@
 	): Record<string, IPullRequestInfo[]> => {
 		const groups: Record<string, IPullRequestInfo[]> = {};
 
-		for (const pr of pull_requests) {
+		// Guard against duplicate PR numbers from older synced data: the keyed
+		// {#each} below treats a repeated key as a fatal error that aborts the
+		// whole list render. New syncs dedupe at fetch time.
+		for (const pr of dedupe_prs_by_number(pull_requests)) {
 			if (!groups[pr.author]) {
 				groups[pr.author] = [];
 			}


### PR DESCRIPTION
## Summary

Fixes the **Contributors page showing no PRs**, and makes each developer's section collapsible for easier scanning.

### The bug
GitHub's paginated `pulls.list` is sorted by `updated` descending, so a PR updated mid-pagination can be returned on two pages. These duplicates flowed into stored data (`data.json` had 365 entries but only 359 unique PR numbers — 6 duplicates). The contributors page keys its `{#each}` on `pr.number`, and Svelte 5 treats a repeated key as a **fatal error that aborts the whole list render**, so the page fell through to "No PRs found." The duplicates also silently **inflated every metric** (PR sizes, contributor and reviewer stats counted those PRs twice).

### The fix
- New pure, client-safe `dedupe_prs_by_number` helper (`src/lib/utils/pull-requests.ts`).
- Dedupe at the fetch chokepoint (`get_recent_pull_requests`) so duplicates never reach storage or any calculation — fixes the crash **and** the metric inflation on the next sync.
- Dedupe defensively when grouping on the contributors page, so existing synced data renders correctly without forcing a re-sync.

### Collapsible sections
- Each developer's PR list is now a native `<details>`/`<summary>` accordion, **collapsed by default** so the page is scannable by author name and PR count.
- Extracted the height-animation logic into a reusable Svelte action (`src/lib/actions/accordion.ts`) applied via `use:accordion`; it tweens open/close with the Web Animations API since `<details>` doesn't animate on its own, and cleans up on `destroy`.
- Native disclosure marker replaced with a chevron that rotates on `[open]`.

### Chore
- Gitignore `.playwright-mcp/` (browser-debugging artifacts).

## Changes
- `src/lib/utils/pull-requests.ts` (new) — `dedupe_prs_by_number` + 5 unit tests
- `src/lib/services/code-reviews.ts` — dedupe at fetch
- `src/routes/contributors/+page.svelte` — defensive dedupe + `<details>` accordion
- `src/lib/actions/accordion.ts` (new) — reusable accordion action
- `.gitignore` — ignore `.playwright-mcp/`

## How to test
1. `npm install` && `npm run dev`, open `/contributors`.
2. **PRs render:** the page lists developer sections with their PR counts (previously blank / "No PRs found"). No `each_key_duplicate` error in the browser console.
3. **Collapsible:** every section starts collapsed. Click a summary — only that section expands (smooth height animation) and its chevron rotates; click again to collapse. Other sections are unaffected.
4. **Exclude still works:** expand a section and toggle a PR's "Exclude" checkbox; the "Recalculate Stats" action appears as before.
5. `npm run check` → 0 errors; `npm run test:unit -- --run` → all pass (includes the new dedupe tests).

## Notes
- Dashboard metric inflation from the duplicates corrects on the next sync, when `data.json` is re-fetched with deduped data; the page-level dedupe only repairs the contributors display for already-stored data.