### PR TITLE
Fix dashboard metric accuracy: time-window filtering, bot exclusion, days-to-merge

### DIFF
--- a/src/lib/services/code-reviews.ts
+++ b/src/lib/services/code-reviews.ts
@@ -4,29 +4,41 @@ import type { RestEndpointMethodTypes } from '@octokit/rest';
 import { Logger } from './logger';
 import { ExclusionsService } from './exclusions';
 import { dedupe_prs_by_number } from '$lib/utils/pull-requests';
+import {
+	is_bot_user,
+	is_closed_unmerged,
+	is_counted_comment,
+	count_reviews_per_day,
+	count_comments_by_pr,
+	calculate_reviewer_stats,
+	calculate_pr_sizes,
+	calculate_contributor_stats,
+	record_from_stored,
+	type ReviewRecord,
+	type CommentRecord,
+	type PullRequestRecord
+} from './metrics';
 import { GITHUB_OWNER, GITHUB_REPO, GITHUB_TOKEN } from '$env/static/private';
 import { ApiError } from '$lib/utils/api-error';
-import type {
-	ICodeReviewsData,
-	IPRSizeStats,
-	IPullRequestInfo,
-	IPRContributorStats,
-	IReviewerStats,
-	IReviewComment
-} from '../../types';
+import type { ICodeReviewsData, IPullRequestInfo, IReviewComment } from '../../types';
 import type { NumericRange } from '@sveltejs/kit';
+
+// Re-exported so existing importers (and tests) keep importing it from here.
+export { is_closed_unmerged };
 
 type PullRequest = RestEndpointMethodTypes['pulls']['list']['response']['data'][number];
 type PullRequestDetail = RestEndpointMethodTypes['pulls']['get']['response']['data'];
 type Review = RestEndpointMethodTypes['pulls']['listReviews']['response']['data'][number];
 
-/**
- * A PR closed without being merged. In GitHub's model a merged PR also has
- * state 'closed' but carries a merged_at timestamp; one closed without merging
- * has none. These were never merged and must not count toward any metric.
- */
-export function is_closed_unmerged(pr: { state: string; merged_at: string | null }): boolean {
-	return pr.state === 'closed' && !pr.merged_at;
+/** A raw inline comment carrying both the metric fields and the feed fields. */
+interface RawReviewComment extends CommentRecord {
+	id: number;
+	pr_title: string;
+	pr_url: string;
+	body: string;
+	path: string;
+	line: number | null;
+	html_url: string;
 }
 
 export class CodeReviewsService {
@@ -124,35 +136,39 @@ export class CodeReviewsService {
 
 			fs.writeFileSync(this.file_name, JSON.stringify(data));
 
+			await this.verify_repository_access();
+
 			// Get exclusions
 			const exclusions_service = new ExclusionsService();
 			const excluded_prs = await exclusions_service.get_excluded_set();
 
-			// Fetch PR details first (needed for both code_reviews and pr_sizes)
+			// Fetch the raw signal: PRs updated in the window, their details, all
+			// reviews, and all inline comments. Filtering (window, self, bot, state)
+			// happens in the pure metric functions, not here.
 			const dates = this.get_date_range();
 			const startDate = this.format_date_for_query(dates[0]);
 			const recentPRs = await this.get_recent_pull_requests(startDate);
 			const prDetails = await this.fetch_pr_details_in_parallel(recentPRs);
 
-			// Fetch review comments for each PR
-			const { countMap: reviewCommentsMap, comments: review_comments } =
-				await this.fetch_review_comments_in_parallel(prDetails);
+			const pr_records = this.to_pr_records(prDetails);
+			const pr_author_map = new Map(pr_records.map((pr) => [pr.number, pr.author]));
 
-			// Extract PR info for storage. prDetails excludes closed-unmerged PRs
-			// (filtered at fetch time); exclusion-list filtering happens per-metric.
-			const pull_requests = this.extract_pr_info(prDetails, reviewCommentsMap);
+			const review_records = await this.fetch_review_records(recentPRs, pr_author_map);
+			const raw_comments = await this.fetch_review_comments(prDetails, pr_author_map);
+			const comments_by_pr = count_comments_by_pr(raw_comments, dates);
 
-			// Calculate stats with exclusions applied
-			const code_reviews = await this.get_code_reviews(excluded_prs, prDetails);
-			const pr_sizes = this.calculate_pr_sizes(prDetails, excluded_prs);
-			const pr_contributor_stats = this.calculate_pr_contributor_stats(
-				prDetails,
-				reviewCommentsMap,
-				excluded_prs
+			// Derive every metric from the normalized records.
+			const code_reviews = count_reviews_per_day(review_records, dates);
+			const reviewer_stats = calculate_reviewer_stats(review_records, raw_comments, dates);
+			const pr_sizes = calculate_pr_sizes(pr_records, excluded_prs, dates);
+			const pr_contributor_stats = calculate_contributor_stats(
+				pr_records,
+				comments_by_pr,
+				excluded_prs,
+				dates
 			);
-
-			// Calculate reviewer stats (PRs reviewed and comments made)
-			const reviewer_stats = await this.calculate_reviewer_stats(recentPRs, prDetails);
+			const pull_requests = this.extract_pr_info(pr_records, comments_by_pr);
+			const review_comments = this.build_comment_feed(raw_comments, dates);
 
 			data = {
 				last_synced: new Date().toISOString(),
@@ -193,27 +209,28 @@ export class CodeReviewsService {
 			const exclusions_service = new ExclusionsService();
 			const excluded_prs = await exclusions_service.get_excluded_set();
 
-			// Recalculate PR sizes from stored pull_requests
-			const pr_sizes = this.calculate_pr_sizes_from_stored(file_data.pull_requests, excluded_prs);
-
-			// Recalculate PR contributor stats from stored pull_requests
-			const pr_contributor_stats = this.calculate_pr_contributor_stats_from_stored(
-				file_data.pull_requests,
-				excluded_prs
+			// Recompute the PR-derived sections from stored PRs. Comments-received per
+			// PR is taken from the stored counts (exclusions don't change it), so the
+			// same metric functions can run without re-fetching raw comments. The
+			// review grid and reviewer stats can't be recomputed without raw reviews,
+			// so they keep their last-synced values (resolved fully by the Postgres
+			// migration, issue #4).
+			const dates = this.get_date_range();
+			const pr_records = file_data.pull_requests.map(record_from_stored);
+			const comments_by_pr = new Map(
+				file_data.pull_requests.map((pr) => [pr.number, pr.review_comments_count])
 			);
 
-			// For code reviews, we need to filter based on excluded PRs
-			// Since we don't store the PR number with each review, we'll recalculate
-			// by filtering the existing data based on excluded PR authors
-			const code_reviews = this.filter_code_reviews(
-				file_data.data,
-				file_data.pull_requests,
-				excluded_prs
+			const pr_sizes = calculate_pr_sizes(pr_records, excluded_prs, dates);
+			const pr_contributor_stats = calculate_contributor_stats(
+				pr_records,
+				comments_by_pr,
+				excluded_prs,
+				dates
 			);
 
 			const data: ICodeReviewsData = {
 				...file_data,
-				data: code_reviews,
 				pr_sizes: pr_sizes,
 				pr_contributor_stats: pr_contributor_stats
 			};
@@ -227,221 +244,59 @@ export class CodeReviewsService {
 		}
 	}
 
+	/** Normalize PR details into metric records, capturing the author's bot flag. */
+	private to_pr_records(prDetails: PullRequestDetail[]): PullRequestRecord[] {
+		return prDetails
+			.filter((pr) => pr.user?.login)
+			.map((pr) => ({
+				number: pr.number,
+				author: pr.user!.login,
+				author_is_bot: is_bot_user(pr.user),
+				title: pr.title,
+				html_url: pr.html_url,
+				additions: pr.additions ?? 0,
+				deletions: pr.deletions ?? 0,
+				created_at: pr.created_at,
+				merged_at: pr.merged_at,
+				state: pr.state as 'open' | 'closed'
+			}));
+	}
+
 	private extract_pr_info(
-		prDetails: PullRequestDetail[],
-		reviewCommentsMap: Map<number, number>
+		pr_records: PullRequestRecord[],
+		comments_by_pr: Map<number, number>
 	): IPullRequestInfo[] {
-		return prDetails.map((pr) => ({
+		return pr_records.map((pr) => ({
 			number: pr.number,
 			title: pr.title,
 			html_url: pr.html_url,
-			author: pr.user?.login ?? 'unknown',
-			additions: pr.additions ?? 0,
-			deletions: pr.deletions ?? 0,
+			author: pr.author,
+			author_is_bot: pr.author_is_bot,
+			additions: pr.additions,
+			deletions: pr.deletions,
 			created_at: pr.created_at,
 			merged_at: pr.merged_at,
-			state: pr.state as 'open' | 'closed',
-			review_comments_count: reviewCommentsMap.get(pr.number) ?? 0
+			state: pr.state,
+			review_comments_count: comments_by_pr.get(pr.number) ?? 0
 		}));
 	}
 
-	private calculate_pr_sizes(
-		prDetails: PullRequestDetail[],
-		excludedPRs: Set<number>
-	): Record<string, IPRSizeStats> {
-		const prsByAuthor: Record<string, number[]> = {};
-
-		for (const pr of prDetails) {
-			const author = pr.user?.login;
-			if (!author) {
-				console.log('Skipping PR with no author:', pr.number);
-				continue;
-			}
-
-			// Skip PRs closed without being merged
-			if (is_closed_unmerged(pr)) continue;
-
-			// Skip excluded PRs
-			if (excludedPRs.has(pr.number)) {
-				console.log(`Skipping excluded PR #${pr.number} by ${author}`);
-				continue;
-			}
-
-			const size = (pr.additions ?? 0) + (pr.deletions ?? 0);
-			console.log(
-				`PR #${pr.number} by ${author}: ${size} lines (${pr.additions} + ${pr.deletions})`
-			);
-
-			if (!prsByAuthor[author]) {
-				prsByAuthor[author] = [];
-			}
-			prsByAuthor[author].push(size);
-		}
-
-		return this.calculate_stats_from_sizes(prsByAuthor);
-	}
-
-	private calculate_pr_sizes_from_stored(
-		pullRequests: IPullRequestInfo[],
-		excludedPRs: Set<number>
-	): Record<string, IPRSizeStats> {
-		const prsByAuthor: Record<string, number[]> = {};
-
-		for (const pr of pullRequests) {
-			// Skip PRs closed without being merged
-			if (is_closed_unmerged(pr)) {
-				continue;
-			}
-
-			// Skip excluded PRs
-			if (excludedPRs.has(pr.number)) {
-				console.log(`Skipping excluded PR #${pr.number} by ${pr.author}`);
-				continue;
-			}
-
-			const size = pr.additions + pr.deletions;
-
-			if (!prsByAuthor[pr.author]) {
-				prsByAuthor[pr.author] = [];
-			}
-			prsByAuthor[pr.author].push(size);
-		}
-
-		return this.calculate_stats_from_sizes(prsByAuthor);
-	}
-
-	private calculate_stats_from_sizes(
-		prsByAuthor: Record<string, number[]>
-	): Record<string, IPRSizeStats> {
-		const result: Record<string, IPRSizeStats> = {};
-
-		for (const [author, sizes] of Object.entries(prsByAuthor)) {
-			if (sizes.length === 0) continue;
-
-			const min = Math.min(...sizes);
-			const max = Math.max(...sizes);
-			const avg = Math.round(sizes.reduce((sum, s) => sum + s, 0) / sizes.length);
-
-			result[author] = {
-				min,
-				max,
-				avg,
-				pr_count: sizes.length
-			};
-		}
-
-		return result;
-	}
-
-	private calculate_pr_contributor_stats_from_stored(
-		pullRequests: IPullRequestInfo[],
-		excludedPRs: Set<number>
-	): IPRContributorStats[] {
-		const dates = this.get_date_range();
-		const statsByAuthor = new Map<string, IPRContributorStats>();
-
-		for (const pr of pullRequests) {
-			const author = pr.author;
-			if (!author) continue;
-
-			// Skip PRs closed without being merged
-			if (is_closed_unmerged(pr)) continue;
-
-			// Skip excluded PRs
-			if (excludedPRs.has(pr.number)) continue;
-
-			const createdDate = pr.created_at.split('T')[0];
-
-			// Only count PRs created within our date range
-			if (createdDate < dates[0] || createdDate > dates[dates.length - 1]) continue;
-
-			if (!statsByAuthor.has(author)) {
-				const prsByDate: Record<string, number> = {};
-				dates.forEach((date) => (prsByDate[date] = 0));
-
-				statsByAuthor.set(author, {
-					author,
-					prs_by_date: prsByDate,
-					prs: [],
-					avg_days_to_merge: null,
-					avg_review_comments: 0,
-					total_prs: 0
-				});
-			}
-
-			const stats = statsByAuthor.get(author)!;
-
-			// Count PRs by date
-			if (stats.prs_by_date[createdDate] !== undefined) {
-				stats.prs_by_date[createdDate]++;
-			}
-
-			// Calculate days to merge or age for open PRs
-			let daysToMerge: number | null = null;
-			if (pr.merged_at) {
-				const created = new Date(pr.created_at);
-				const merged = new Date(pr.merged_at);
-				daysToMerge = Math.ceil((merged.getTime() - created.getTime()) / (1000 * 60 * 60 * 24));
-			} else if (pr.state === 'open') {
-				const created = new Date(pr.created_at);
-				const now = new Date();
-				daysToMerge = Math.ceil((now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24));
-			}
-
-			stats.prs.push({
-				number: pr.number,
-				title: pr.title,
-				html_url: pr.html_url,
-				created_at: pr.created_at,
-				merged_at: pr.merged_at,
-				state: pr.state,
-				days_to_merge: daysToMerge,
-				review_comments_count: pr.review_comments_count
-			});
-
-			stats.total_prs++;
-		}
-
-		// Calculate averages for each author
-		for (const stats of statsByAuthor.values()) {
-			const prsWithMergeTime = stats.prs.filter((pr) => pr.days_to_merge !== null);
-			if (prsWithMergeTime.length > 0) {
-				const totalDays = prsWithMergeTime.reduce((sum, pr) => sum + (pr.days_to_merge ?? 0), 0);
-				stats.avg_days_to_merge = Math.round((totalDays / prsWithMergeTime.length) * 10) / 10;
-			}
-
-			const totalComments = stats.prs.reduce((sum, pr) => sum + pr.review_comments_count, 0);
-			stats.avg_review_comments =
-				stats.prs.length > 0 ? Math.round((totalComments / stats.prs.length) * 10) / 10 : 0;
-		}
-
-		// Sort by total PRs descending
-		return Array.from(statsByAuthor.values()).sort((a, b) => b.total_prs - a.total_prs);
-	}
-
-	private filter_code_reviews(
-		codeReviews: Record<string, Record<string, number>>,
-		pullRequests: IPullRequestInfo[],
-		excludedPRs: Set<number>
-	): Record<string, Record<string, number>> {
-		// Build a map of excluded PR authors
-		const excludedAuthors = new Set<string>();
-		for (const pr of pullRequests) {
-			if (excludedPRs.has(pr.number)) {
-				excludedAuthors.add(pr.author);
-			}
-		}
-
-		// If no PRs are excluded, return as-is
-		if (excludedAuthors.size === 0) {
-			return codeReviews;
-		}
-
-		// Note: This is a simplified approach. Since we don't track which reviews
-		// belong to which PRs, we cannot fully filter reviews on excluded PRs.
-		// The full filtering happens during sync when we have access to review data.
-		// For recalculation, we return the existing code reviews unchanged.
-		return codeReviews;
+	/** The comments feed: qualifying (in-window, non-self, non-bot) comments only. */
+	private build_comment_feed(comments: RawReviewComment[], dates: string[]): IReviewComment[] {
+		return comments
+			.filter((comment) => is_counted_comment(comment, dates))
+			.map((comment) => ({
+				id: comment.id,
+				pr_number: comment.pr_number,
+				pr_title: comment.pr_title,
+				pr_url: comment.pr_url,
+				author: comment.author,
+				body: comment.body,
+				path: comment.path,
+				line: comment.line,
+				created_at: comment.created_at,
+				html_url: comment.html_url
+			}));
 	}
 
 	private format_date_for_query(date: string) {
@@ -511,69 +366,28 @@ export class CodeReviewsService {
 		return allReviews;
 	};
 
-	private get_code_reviews = async (
-		excludedPRs: Set<number>,
-		prDetails: PullRequestDetail[]
-	): Promise<Record<string, Record<string, number>>> => {
-		try {
-			// First verify we have access to the repository
-			await this.verify_repository_access();
+	/** Fetch all reviews and normalize them into metric records. */
+	private fetch_review_records = async (
+		recentPRs: PullRequest[],
+		prAuthorMap: Map<number, string>
+	): Promise<ReviewRecord[]> => {
+		const allReviews = await this.fetch_reviews_in_parallel(recentPRs);
 
-			const dates = this.get_date_range();
-			const startDate = this.format_date_for_query(dates[0]);
-
-			console.log('Fetching PR reviews... This may take a moment...');
-
-			// Build a map of PR number to author for exclusion filtering
-			const prAuthorMap = new Map<number, string>();
-			for (const pr of prDetails) {
-				if (pr.user?.login) {
-					prAuthorMap.set(pr.number, pr.user.login);
-				}
-			}
-
-			// Get all PR reviews within the date range
-			const recentPRs = await this.get_recent_pull_requests(startDate);
-			const allReviews = await this.fetch_reviews_in_parallel(recentPRs);
-
-			// Filter reviews by date
-			const reviews = allReviews.filter((review: Review) => {
-				const reviewDate = new Date(review.submitted_at!);
-				return reviewDate >= new Date(startDate);
+		return allReviews
+			.filter((review) => review.user?.login)
+			.map((review) => {
+				const pr_number = review.pull_request_url
+					? parseInt(review.pull_request_url.split('/').pop() || '0')
+					: 0;
+				return {
+					pr_number,
+					pr_author: prAuthorMap.get(pr_number) ?? '',
+					reviewer: review.user!.login,
+					reviewer_is_bot: is_bot_user(review.user),
+					state: (review.state ?? '').toUpperCase(),
+					submitted_at: review.submitted_at ?? null
+				};
 			});
-
-			// Process reviews by user and date, excluding self-reviews
-			const userStats: Record<string, Record<string, number>> = {};
-
-			reviews.forEach((review: Review) => {
-				const reviewDate = review.submitted_at!.split('T')[0];
-				if (reviewDate >= dates[0] && reviewDate <= dates[this.numberOfDays - 1]) {
-					const username: string = review.user!.login;
-					const prNumber = review.pull_request_url
-						? parseInt(review.pull_request_url.split('/').pop() || '0')
-						: 0;
-
-					const prAuthor = prAuthorMap.get(prNumber);
-
-					// Skip self-reviews (reviews on the reviewer's own PR)
-					if (prAuthor === username) {
-						console.log(`Skipping self-review by ${username} on their own PR #${prNumber}`);
-						return;
-					}
-
-					if (!userStats[username]) {
-						userStats[username] = {};
-						dates.forEach((date) => (userStats[username][date] = 0));
-					}
-					userStats[username][reviewDate]++;
-				}
-			});
-
-			return userStats;
-		} catch (error: unknown) {
-			Logger.error(error);
-			throw error;
-		}
 	};
 
 	private get_date_range() {
@@ -638,20 +452,22 @@ export class CodeReviewsService {
 		return allDetails;
 	};
 
-	private fetch_review_comments_in_parallel = async (
-		prDetails: PullRequestDetail[]
-	): Promise<{ countMap: Map<number, number>; comments: IReviewComment[] }> => {
+	/**
+	 * Fetch all inline review comments and normalize them. Comments are kept raw
+	 * (including the PR author's own and bots); the metric functions apply the
+	 * self/bot/window filters so the rules can change without re-fetching.
+	 */
+	private fetch_review_comments = async (
+		prDetails: PullRequestDetail[],
+		prAuthorMap: Map<number, string>
+	): Promise<RawReviewComment[]> => {
 		const BATCH_SIZE = 10;
-		const reviewCommentsMap = new Map<number, number>();
-		const allReviewComments: IReviewComment[] = [];
-
-		console.log('Fetching review comments for PRs...');
+		const allComments: RawReviewComment[] = [];
 
 		for (let i = 0; i < prDetails.length; i += BATCH_SIZE) {
 			const batch = prDetails.slice(i, i + BATCH_SIZE);
 			const batchResults = await Promise.all(
 				batch.map(async (pr) => {
-					const prAuthor = pr.user?.login;
 					const comments = await this.octokit.paginate(this.octokit.rest.pulls.listReviewComments, {
 						owner: GITHUB_OWNER,
 						repo: GITHUB_REPO,
@@ -659,229 +475,32 @@ export class CodeReviewsService {
 						per_page: 100
 					});
 
-					// Filter to only comments from other devs (not the PR author)
-					const otherDevComments = comments.filter((comment) => comment.user?.login !== prAuthor);
-
-					// Extract full comment data
-					const extractedComments: IReviewComment[] = otherDevComments.map((comment) => ({
-						id: comment.id,
-						pr_number: pr.number,
-						pr_title: pr.title,
-						pr_url: pr.html_url,
-						author: comment.user?.login ?? 'unknown',
-						body: comment.body,
-						path: comment.path,
-						line: comment.line ?? comment.original_line ?? null,
-						created_at: comment.created_at,
-						html_url: comment.html_url
-					}));
-
-					return {
-						prNumber: pr.number,
-						count: otherDevComments.length,
-						comments: extractedComments
-					};
+					return comments
+						.filter((comment) => comment.user?.login)
+						.map(
+							(comment): RawReviewComment => ({
+								pr_number: pr.number,
+								pr_author: prAuthorMap.get(pr.number) ?? '',
+								author: comment.user!.login,
+								author_is_bot: is_bot_user(comment.user),
+								created_at: comment.created_at,
+								id: comment.id,
+								pr_title: pr.title,
+								pr_url: pr.html_url,
+								body: comment.body,
+								path: comment.path,
+								line: comment.line ?? comment.original_line ?? null,
+								html_url: comment.html_url
+							})
+						);
 				})
 			);
 
 			for (const result of batchResults) {
-				reviewCommentsMap.set(result.prNumber, result.count);
-				allReviewComments.push(...result.comments);
+				allComments.push(...result);
 			}
 		}
 
-		return { countMap: reviewCommentsMap, comments: allReviewComments };
+		return allComments;
 	};
-
-	private calculate_pr_contributor_stats(
-		prDetails: PullRequestDetail[],
-		reviewCommentsMap: Map<number, number>,
-		excludedPRs: Set<number>
-	): IPRContributorStats[] {
-		const dates = this.get_date_range();
-		const statsByAuthor = new Map<string, IPRContributorStats>();
-
-		for (const pr of prDetails) {
-			const author = pr.user?.login;
-			if (!author) continue;
-
-			// Skip PRs closed without being merged. prDetails already flows from a
-			// filtered list, but this keeps the invariant explicit at the call site.
-			if (is_closed_unmerged(pr)) continue;
-
-			// Skip excluded PRs
-			if (excludedPRs.has(pr.number)) continue;
-
-			const createdDate = pr.created_at.split('T')[0];
-
-			// Only count PRs created within our date range
-			if (createdDate < dates[0] || createdDate > dates[dates.length - 1]) continue;
-
-			if (!statsByAuthor.has(author)) {
-				const prsByDate: Record<string, number> = {};
-				dates.forEach((date) => (prsByDate[date] = 0));
-
-				statsByAuthor.set(author, {
-					author,
-					prs_by_date: prsByDate,
-					prs: [],
-					avg_days_to_merge: null,
-					avg_review_comments: 0,
-					total_prs: 0
-				});
-			}
-
-			const stats = statsByAuthor.get(author)!;
-
-			// Count PRs by date
-			if (stats.prs_by_date[createdDate] !== undefined) {
-				stats.prs_by_date[createdDate]++;
-			}
-
-			// Calculate days to merge or age for open PRs
-			let daysToMerge: number | null = null;
-			if (pr.merged_at) {
-				const created = new Date(pr.created_at);
-				const merged = new Date(pr.merged_at);
-				daysToMerge = Math.ceil((merged.getTime() - created.getTime()) / (1000 * 60 * 60 * 24));
-			} else if (pr.state === 'open') {
-				const created = new Date(pr.created_at);
-				const now = new Date();
-				daysToMerge = Math.ceil((now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24));
-			}
-
-			const reviewComments = reviewCommentsMap.get(pr.number) ?? 0;
-
-			stats.prs.push({
-				number: pr.number,
-				title: pr.title,
-				html_url: pr.html_url,
-				created_at: pr.created_at,
-				merged_at: pr.merged_at,
-				state: pr.state as 'open' | 'closed',
-				days_to_merge: daysToMerge,
-				review_comments_count: reviewComments
-			});
-
-			stats.total_prs++;
-		}
-
-		// Calculate averages for each author
-		for (const stats of statsByAuthor.values()) {
-			const prsWithMergeTime = stats.prs.filter((pr) => pr.days_to_merge !== null);
-			if (prsWithMergeTime.length > 0) {
-				const totalDays = prsWithMergeTime.reduce((sum, pr) => sum + (pr.days_to_merge ?? 0), 0);
-				stats.avg_days_to_merge = Math.round((totalDays / prsWithMergeTime.length) * 10) / 10;
-			}
-
-			const totalComments = stats.prs.reduce((sum, pr) => sum + pr.review_comments_count, 0);
-			stats.avg_review_comments =
-				stats.prs.length > 0 ? Math.round((totalComments / stats.prs.length) * 10) / 10 : 0;
-		}
-
-		// Sort by total PRs descending
-		return Array.from(statsByAuthor.values()).sort((a, b) => b.total_prs - a.total_prs);
-	}
-
-	private async calculate_reviewer_stats(
-		recentPRs: PullRequest[],
-		prDetails: PullRequestDetail[]
-	): Promise<Record<string, IReviewerStats>> {
-		console.log('Calculating reviewer stats...');
-
-		// Build a map of PR number to author
-		const prAuthorMap = new Map<number, string>();
-		for (const pr of prDetails) {
-			if (pr.user?.login) {
-				prAuthorMap.set(pr.number, pr.user.login);
-			}
-		}
-
-		// Fetch all reviews
-		const allReviews = await this.fetch_reviews_in_parallel(recentPRs);
-
-		// Track unique PRs reviewed by each reviewer (excluding self-reviews)
-		const reviewerPRs = new Map<string, Set<number>>();
-
-		for (const review of allReviews) {
-			const reviewer = review.user?.login;
-			if (!reviewer) continue;
-
-			const prNumber = review.pull_request_url
-				? parseInt(review.pull_request_url.split('/').pop() || '0')
-				: 0;
-
-			const prAuthor = prAuthorMap.get(prNumber);
-
-			// Skip self-reviews
-			if (prAuthor === reviewer) continue;
-
-			if (!reviewerPRs.has(reviewer)) {
-				reviewerPRs.set(reviewer, new Set());
-			}
-			reviewerPRs.get(reviewer)!.add(prNumber);
-		}
-
-		// Fetch all review comments and count by reviewer (excluding self-comments)
-		const reviewerComments = new Map<string, number>();
-		const BATCH_SIZE = 10;
-
-		for (let i = 0; i < prDetails.length; i += BATCH_SIZE) {
-			const batch = prDetails.slice(i, i + BATCH_SIZE);
-			const batchResults = await Promise.all(
-				batch.map(async (pr) => {
-					const prAuthor = pr.user?.login;
-					const comments = await this.octokit.paginate(this.octokit.rest.pulls.listReviewComments, {
-						owner: GITHUB_OWNER,
-						repo: GITHUB_REPO,
-						pull_number: pr.number,
-						per_page: 100
-					});
-
-					// Count comments by each reviewer (excluding self-comments)
-					const commentsByReviewer = new Map<string, number>();
-					for (const comment of comments) {
-						const commenter = comment.user?.login;
-						if (!commenter || commenter === prAuthor) continue;
-
-						commentsByReviewer.set(commenter, (commentsByReviewer.get(commenter) || 0) + 1);
-					}
-
-					return commentsByReviewer;
-				})
-			);
-
-			// Aggregate comment counts
-			for (const commentMap of batchResults) {
-				for (const [reviewer, count] of commentMap) {
-					reviewerComments.set(reviewer, (reviewerComments.get(reviewer) || 0) + count);
-				}
-			}
-		}
-
-		// Build the reviewer stats
-		const result: Record<string, IReviewerStats> = {};
-
-		// Get all unique reviewers from both reviews and comments
-		const allReviewers = new Set([...reviewerPRs.keys(), ...reviewerComments.keys()]);
-
-		for (const reviewer of allReviewers) {
-			const reviewedPRs = reviewerPRs.get(reviewer);
-			const prsReviewed = reviewedPRs?.size || 0;
-			const totalComments = reviewerComments.get(reviewer) || 0;
-
-			result[reviewer] = {
-				reviewer,
-				total_prs_reviewed: prsReviewed,
-				total_review_comments: totalComments,
-				avg_comments_per_pr:
-					prsReviewed > 0 ? Math.round((totalComments / prsReviewed) * 10) / 10 : 0,
-				// Persist the distinct PR numbers so the team-wide distinct count can be
-				// computed as a union across only the currently-visible reviewers.
-				reviewed_pr_numbers: reviewedPRs ? [...reviewedPRs] : []
-			};
-		}
-
-		return result;
-	}
 }

--- a/src/lib/services/code-reviews.ts
+++ b/src/lib/services/code-reviews.ts
@@ -8,6 +8,7 @@ import {
 	is_bot_user,
 	is_closed_unmerged,
 	is_counted_comment,
+	get_date_range,
 	count_reviews_per_day,
 	count_comments_by_pr,
 	calculate_reviewer_stats,
@@ -391,13 +392,7 @@ export class CodeReviewsService {
 	};
 
 	private get_date_range() {
-		const dates = [];
-		for (let i = 0; i < this.numberOfDays; i++) {
-			const date = new Date();
-			date.setDate(date.getDate() - i);
-			dates.unshift(date.toISOString().split('T')[0]);
-		}
-		return dates;
+		return get_date_range(this.numberOfDays);
 	}
 
 	private verify_repository_access = async () => {

--- a/src/lib/services/metrics.test.ts
+++ b/src/lib/services/metrics.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from 'vitest';
+import {
+	is_bot_user,
+	is_closed_unmerged,
+	is_counted_review,
+	is_counted_comment,
+	days_to_merge,
+	count_reviews_per_day,
+	count_comments_by_pr,
+	calculate_reviewer_stats,
+	calculate_pr_sizes,
+	calculate_contributor_stats,
+	type ReviewRecord,
+	type CommentRecord,
+	type PullRequestRecord
+} from './metrics';
+
+// A 14-day window, June 1–14 2026. Out-of-window dates sit before June 1.
+const DATES = [
+	'2026-06-01',
+	'2026-06-02',
+	'2026-06-03',
+	'2026-06-04',
+	'2026-06-05',
+	'2026-06-06',
+	'2026-06-07',
+	'2026-06-08',
+	'2026-06-09',
+	'2026-06-10',
+	'2026-06-11',
+	'2026-06-12',
+	'2026-06-13',
+	'2026-06-14'
+];
+const IN = '2026-06-10T12:00:00Z';
+const OUT = '2026-05-20T12:00:00Z'; // before the window
+
+function review(over: Partial<ReviewRecord> = {}): ReviewRecord {
+	return {
+		pr_number: 1,
+		pr_author: 'author',
+		reviewer: 'reviewer',
+		reviewer_is_bot: false,
+		state: 'APPROVED',
+		submitted_at: IN,
+		...over
+	};
+}
+
+function comment(over: Partial<CommentRecord> = {}): CommentRecord {
+	return {
+		pr_number: 1,
+		pr_author: 'author',
+		author: 'commenter',
+		author_is_bot: false,
+		created_at: IN,
+		...over
+	};
+}
+
+function pr(over: Partial<PullRequestRecord> = {}): PullRequestRecord {
+	return {
+		number: 1,
+		author: 'author',
+		author_is_bot: false,
+		title: 'PR',
+		html_url: 'https://example.com/1',
+		additions: 10,
+		deletions: 5,
+		created_at: IN,
+		merged_at: null,
+		state: 'open',
+		...over
+	};
+}
+
+describe('is_bot_user', () => {
+	it('flags accounts with type Bot', () => {
+		expect(is_bot_user({ login: 'sentry-io', type: 'Bot' })).toBe(true);
+	});
+	it('flags [bot]-suffixed logins as a fallback', () => {
+		expect(is_bot_user({ login: 'coderabbitai[bot]', type: undefined })).toBe(true);
+	});
+	it('does not flag normal users', () => {
+		expect(is_bot_user({ login: 'jake-lundberg', type: 'User' })).toBe(false);
+	});
+	it('handles null safely', () => {
+		expect(is_bot_user(null)).toBe(false);
+	});
+});
+
+describe('is_closed_unmerged', () => {
+	it('is true only for closed PRs with no merged_at', () => {
+		expect(is_closed_unmerged({ state: 'closed', merged_at: null })).toBe(true);
+		expect(is_closed_unmerged({ state: 'closed', merged_at: '2026-06-10T00:00:00Z' })).toBe(false);
+		expect(is_closed_unmerged({ state: 'open', merged_at: null })).toBe(false);
+	});
+});
+
+describe('is_counted_review', () => {
+	it('counts a qualifying in-window non-self non-bot review', () => {
+		expect(is_counted_review(review(), DATES)).toBe(true);
+	});
+
+	it('counts COMMENTED and CHANGES_REQUESTED, not DISMISSED or PENDING', () => {
+		expect(is_counted_review(review({ state: 'COMMENTED' }), DATES)).toBe(true);
+		expect(is_counted_review(review({ state: 'CHANGES_REQUESTED' }), DATES)).toBe(true);
+		expect(is_counted_review(review({ state: 'DISMISSED' }), DATES)).toBe(false);
+		expect(is_counted_review(review({ state: 'PENDING' }), DATES)).toBe(false);
+	});
+
+	it('excludes a review submitted outside the window even if its PR is recent', () => {
+		// This is the core of the 255 bug: an old review on a still-active PR.
+		expect(is_counted_review(review({ submitted_at: OUT }), DATES)).toBe(false);
+	});
+
+	it('counts an in-window review regardless of how old its PR is', () => {
+		// The record carries no PR age, proving PR age cannot pull or push a review
+		// in/out of the window — only the review's own submitted_at matters.
+		expect(is_counted_review(review({ pr_number: 206, submitted_at: IN }), DATES)).toBe(true);
+	});
+
+	it('excludes self-reviews and bot reviews', () => {
+		expect(is_counted_review(review({ reviewer: 'author' }), DATES)).toBe(false);
+		expect(is_counted_review(review({ reviewer_is_bot: true }), DATES)).toBe(false);
+	});
+});
+
+describe('is_counted_comment', () => {
+	it('counts in-window non-self non-bot comments', () => {
+		expect(is_counted_comment(comment(), DATES)).toBe(true);
+	});
+	it('excludes out-of-window, self, and bot comments', () => {
+		expect(is_counted_comment(comment({ created_at: OUT }), DATES)).toBe(false);
+		expect(is_counted_comment(comment({ author: 'author' }), DATES)).toBe(false);
+		expect(is_counted_comment(comment({ author_is_bot: true }), DATES)).toBe(false);
+	});
+});
+
+describe('days_to_merge', () => {
+	it('returns whole days for a merged PR', () => {
+		expect(
+			days_to_merge({ created_at: '2026-06-01T00:00:00Z', merged_at: '2026-06-04T00:00:00Z' })
+		).toBe(3);
+	});
+	it('returns null for an open (never-merged) PR', () => {
+		expect(days_to_merge({ created_at: '2026-06-01T00:00:00Z', merged_at: null })).toBeNull();
+	});
+});
+
+describe('count_reviews_per_day', () => {
+	it('counts review EVENTS per day, so re-reviewing one PR three times in a day is 3', () => {
+		const reviews = [
+			review({ submitted_at: '2026-06-10T09:00:00Z' }),
+			review({ submitted_at: '2026-06-10T10:00:00Z' }),
+			review({ submitted_at: '2026-06-10T11:00:00Z' })
+		];
+		const grid = count_reviews_per_day(reviews, DATES);
+		expect(grid['reviewer']['2026-06-10']).toBe(3);
+	});
+
+	it('omits out-of-window, dismissed, self, and bot reviews from the grid', () => {
+		const reviews = [
+			review({ submitted_at: OUT }),
+			review({ state: 'DISMISSED' }),
+			review({ reviewer: 'author' }),
+			review({ reviewer_is_bot: true })
+		];
+		expect(count_reviews_per_day(reviews, DATES)).toEqual({});
+	});
+});
+
+describe('calculate_reviewer_stats', () => {
+	it('counts DISTINCT PRs reviewed, so re-reviewing one PR is 1', () => {
+		const reviews = [
+			review({ pr_number: 5, submitted_at: '2026-06-10T09:00:00Z' }),
+			review({ pr_number: 5, submitted_at: '2026-06-11T09:00:00Z' })
+		];
+		const stats = calculate_reviewer_stats(reviews, [], DATES);
+		expect(stats['reviewer'].total_prs_reviewed).toBe(1);
+		expect(stats['reviewer'].reviewed_pr_numbers).toEqual([5]);
+	});
+
+	it('counts qualifying comments and derives avg comments per PR', () => {
+		const reviews = [review({ pr_number: 1 }), review({ pr_number: 2 })];
+		const comments = [
+			comment({ author: 'reviewer', pr_number: 1 }),
+			comment({ author: 'reviewer', pr_number: 1 }),
+			comment({ author: 'reviewer', pr_number: 2 })
+		];
+		const stats = calculate_reviewer_stats(reviews, comments, DATES);
+		expect(stats['reviewer'].total_prs_reviewed).toBe(2);
+		expect(stats['reviewer'].total_review_comments).toBe(3);
+		expect(stats['reviewer'].avg_comments_per_pr).toBe(1.5);
+	});
+
+	it('excludes all activity from bots and out-of-window events', () => {
+		const reviews = [
+			review({ reviewer: 'sentry[bot]', reviewer_is_bot: true }),
+			review({ reviewer: 'human', submitted_at: OUT })
+		];
+		expect(calculate_reviewer_stats(reviews, [], DATES)).toEqual({});
+	});
+});
+
+describe('calculate_pr_sizes', () => {
+	it('aggregates size only over PRs created in the window', () => {
+		const prs = [
+			pr({
+				number: 1,
+				author: 'dev',
+				additions: 100,
+				deletions: 0,
+				created_at: '2026-06-05T00:00:00Z'
+			}),
+			pr({
+				number: 2,
+				author: 'dev',
+				additions: 50,
+				deletions: 50,
+				created_at: '2026-06-06T00:00:00Z'
+			}),
+			// created before the window — must be ignored
+			pr({ number: 3, author: 'dev', additions: 999, deletions: 0, created_at: OUT })
+		];
+		const sizes = calculate_pr_sizes(prs, new Set(), DATES);
+		expect(sizes['dev']).toEqual({ min: 100, max: 100, avg: 100, pr_count: 2 });
+	});
+
+	it('excludes closed-unmerged, excluded, and bot-authored PRs', () => {
+		const prs = [
+			pr({ number: 1, author: 'dev', state: 'closed', merged_at: null }), // closed-unmerged
+			pr({ number: 2, author: 'dev' }), // excluded by id
+			pr({ number: 3, author: 'bot', author_is_bot: true })
+		];
+		expect(calculate_pr_sizes(prs, new Set([2]), DATES)).toEqual({});
+	});
+});
+
+describe('calculate_contributor_stats', () => {
+	it('averages days-to-merge over merged PRs only, excluding open PRs', () => {
+		const prs = [
+			pr({
+				number: 1,
+				author: 'dev',
+				state: 'closed',
+				created_at: '2026-06-01T00:00:00Z',
+				merged_at: '2026-06-05T00:00:00Z' // 4 days
+			}),
+			pr({
+				number: 2,
+				author: 'dev',
+				state: 'closed',
+				created_at: '2026-06-02T00:00:00Z',
+				merged_at: '2026-06-04T00:00:00Z' // 2 days
+			}),
+			// open PR created in window — counts toward total_prs but NOT days-to-merge
+			pr({ number: 3, author: 'dev', state: 'open', created_at: '2026-06-01T00:00:00Z' })
+		];
+		const [stats] = calculate_contributor_stats(prs, new Map(), new Set(), DATES);
+		expect(stats.total_prs).toBe(3);
+		expect(stats.avg_days_to_merge).toBe(3); // (4 + 2) / 2, open PR not averaged in
+		expect(stats.prs.find((p) => p.number === 3)!.days_to_merge).toBeNull();
+	});
+
+	it('counts comments received per PR from qualifying comments only', () => {
+		const prs = [pr({ number: 7, author: 'dev', created_at: '2026-06-05T00:00:00Z' })];
+		const comments = [
+			comment({ pr_number: 7, pr_author: 'dev', author: 'reviewer' }),
+			comment({ pr_number: 7, pr_author: 'dev', author: 'reviewer' }),
+			comment({ pr_number: 7, pr_author: 'dev', author: 'dev' }), // self — excluded
+			comment({ pr_number: 7, pr_author: 'dev', author: 'bot', author_is_bot: true }) // bot — excluded
+		];
+		const counts = count_comments_by_pr(comments, DATES);
+		expect(counts.get(7)).toBe(2);
+		const [stats] = calculate_contributor_stats(prs, counts, new Set(), DATES);
+		expect(stats.prs[0].review_comments_count).toBe(2);
+		expect(stats.avg_review_comments).toBe(2);
+	});
+
+	it('buckets PRs by their creation date', () => {
+		const prs = [
+			pr({ number: 1, author: 'dev', created_at: '2026-06-05T08:00:00Z' }),
+			pr({ number: 2, author: 'dev', created_at: '2026-06-05T20:00:00Z' })
+		];
+		const [stats] = calculate_contributor_stats(prs, new Map(), new Set(), DATES);
+		expect(stats.prs_by_date['2026-06-05']).toBe(2);
+	});
+});

--- a/src/lib/services/metrics.test.ts
+++ b/src/lib/services/metrics.test.ts
@@ -11,6 +11,8 @@ import {
 	calculate_pr_sizes,
 	calculate_contributor_stats,
 	record_from_stored,
+	get_date_range,
+	prs_created_in_window,
 	type ReviewRecord,
 	type CommentRecord,
 	type PullRequestRecord
@@ -186,6 +188,42 @@ describe('record_from_stored', () => {
 			review_comments_count: 0
 		};
 		expect(record_from_stored(stored).author_is_bot).toBe(true);
+	});
+});
+
+describe('get_date_range', () => {
+	it('returns N consecutive ascending day strings ending today', () => {
+		const range = get_date_range(14, new Date('2026-06-14T12:00:00Z'));
+		expect(range).toHaveLength(14);
+		expect(range[0]).toBe('2026-06-01');
+		expect(range[13]).toBe('2026-06-14');
+	});
+});
+
+describe('prs_created_in_window', () => {
+	const window = ['2026-06-01', '2026-06-02', '2026-06-03'];
+
+	it('keeps only PRs created within the window', () => {
+		const prs = [
+			{ number: 1, created_at: '2026-06-02T10:00:00Z' },
+			{ number: 2, created_at: '2025-10-10T10:00:00Z' }, // ancient, merely active recently
+			{ number: 3, created_at: '2026-06-03T23:59:00Z' }
+		];
+		expect(prs_created_in_window(prs, window).map((p) => p.number)).toEqual([1, 3]);
+	});
+
+	it('excludes bot-authored PRs', () => {
+		const prs = [
+			{ number: 1, created_at: '2026-06-02T10:00:00Z', author_is_bot: true },
+			{ number: 2, created_at: '2026-06-02T10:00:00Z', author_is_bot: false }
+		];
+		expect(prs_created_in_window(prs, window).map((p) => p.number)).toEqual([2]);
+	});
+
+	it('keeps excluded PRs (the view shows them so they can be toggled)', () => {
+		// The helper does not take an exclusion set — excluded PRs remain visible.
+		const prs = [{ number: 99, created_at: '2026-06-01T00:00:00Z' }];
+		expect(prs_created_in_window(prs, window)).toHaveLength(1);
 	});
 });
 

--- a/src/lib/services/metrics.test.ts
+++ b/src/lib/services/metrics.test.ts
@@ -198,18 +198,37 @@ describe('get_date_range', () => {
 		expect(range[0]).toBe('2026-06-01');
 		expect(range[13]).toBe('2026-06-14');
 	});
+
+	it('returns a single day for numberOfDays = 1', () => {
+		expect(get_date_range(1, new Date('2026-06-14T12:00:00Z'))).toEqual(['2026-06-14']);
+	});
+
+	it('returns an empty array for numberOfDays = 0', () => {
+		expect(get_date_range(0, new Date('2026-06-14T12:00:00Z'))).toEqual([]);
+	});
 });
 
 describe('prs_created_in_window', () => {
 	const window = ['2026-06-01', '2026-06-02', '2026-06-03'];
 
-	it('keeps only PRs created within the window', () => {
+	it('keeps only PRs created within the window, inclusive of both edges', () => {
 		const prs = [
-			{ number: 1, created_at: '2026-06-02T10:00:00Z' },
+			{ number: 1, created_at: '2026-06-01T00:00:00Z' }, // first day (inclusive)
 			{ number: 2, created_at: '2025-10-10T10:00:00Z' }, // ancient, merely active recently
-			{ number: 3, created_at: '2026-06-03T23:59:00Z' }
+			{ number: 3, created_at: '2026-06-03T23:59:00Z' } // last day (inclusive)
 		];
 		expect(prs_created_in_window(prs, window).map((p) => p.number)).toEqual([1, 3]);
+	});
+
+	it('treats a missing author_is_bot (older stored data) as a human PR', () => {
+		const prs = [{ number: 1, created_at: '2026-06-02T10:00:00Z' }]; // author_is_bot absent
+		expect(prs_created_in_window(prs, window)).toHaveLength(1);
+	});
+
+	it('returns nothing when the window is empty', () => {
+		expect(prs_created_in_window([{ number: 1, created_at: '2026-06-02T10:00:00Z' }], [])).toEqual(
+			[]
+		);
 	});
 
 	it('excludes bot-authored PRs', () => {

--- a/src/lib/services/metrics.test.ts
+++ b/src/lib/services/metrics.test.ts
@@ -10,6 +10,7 @@ import {
 	calculate_reviewer_stats,
 	calculate_pr_sizes,
 	calculate_contributor_stats,
+	record_from_stored,
 	type ReviewRecord,
 	type CommentRecord,
 	type PullRequestRecord
@@ -145,6 +146,46 @@ describe('days_to_merge', () => {
 	});
 	it('returns null for an open (never-merged) PR', () => {
 		expect(days_to_merge({ created_at: '2026-06-01T00:00:00Z', merged_at: null })).toBeNull();
+	});
+	it('rounds a sub-day merge up to 1, never 0', () => {
+		expect(
+			days_to_merge({ created_at: '2026-06-01T00:00:00Z', merged_at: '2026-06-01T00:00:05Z' })
+		).toBe(1);
+	});
+});
+
+describe('record_from_stored', () => {
+	it('defaults author_is_bot to false when absent on older stored PRs', () => {
+		const stored = {
+			number: 1,
+			title: 'PR',
+			html_url: 'https://example.com/1',
+			author: 'dev',
+			additions: 10,
+			deletions: 5,
+			created_at: IN,
+			merged_at: null,
+			state: 'open' as const,
+			review_comments_count: 0
+		};
+		expect(record_from_stored(stored).author_is_bot).toBe(false);
+	});
+
+	it('preserves author_is_bot when present', () => {
+		const stored = {
+			number: 2,
+			title: 'PR',
+			html_url: 'https://example.com/2',
+			author: 'sentry[bot]',
+			author_is_bot: true,
+			additions: 1,
+			deletions: 1,
+			created_at: IN,
+			merged_at: null,
+			state: 'open' as const,
+			review_comments_count: 0
+		};
+		expect(record_from_stored(stored).author_is_bot).toBe(true);
 	});
 });
 

--- a/src/lib/services/metrics.ts
+++ b/src/lib/services/metrics.ts
@@ -82,7 +82,12 @@ export function is_bot_user(user: { login?: string | null; type?: string | null 
 	return /\[bot\]$/i.test(user.login ?? '');
 }
 
-/** Inclusive YYYY-MM-DD comparison of an ISO timestamp against the window edges. */
+/**
+ * Inclusive YYYY-MM-DD comparison of an ISO timestamp against the window edges.
+ * `dates` is assumed to be a consecutive, ascending run of days (as produced by
+ * the service's get_date_range), so a range check against the first/last entry
+ * is equivalent to set membership and avoids per-call Set construction.
+ */
 function date_in_window(iso: string | null, dates: string[]): boolean {
 	if (!iso || dates.length === 0) return false;
 	const day = iso.split('T')[0];
@@ -108,7 +113,11 @@ export function is_counted_comment(comment: CommentRecord, dates: string[]): boo
 	);
 }
 
-/** Days between creation and merge for a merged PR; null for anything not merged. */
+/**
+ * Days between creation and merge for a merged PR; null for anything not merged.
+ * Rounds UP to whole days, so any PR merged within its first 24 hours counts as
+ * 1 day (never 0) — a same-hour merge still represents a day's worth of cycle.
+ */
 export function days_to_merge(pr: { created_at: string; merged_at: string | null }): number | null {
 	if (!pr.merged_at) return null;
 	const created = new Date(pr.created_at).getTime();

--- a/src/lib/services/metrics.ts
+++ b/src/lib/services/metrics.ts
@@ -114,6 +114,10 @@ export function get_date_range(numberOfDays = 14, now: Date = new Date()): strin
  * window" definition — rather than every PR merely *updated* in the window
  * (which drags in ancient PRs that received recent activity). Excluded PRs are
  * intentionally kept so the contributors view can still display/toggle them.
+ *
+ * Unlike `contribution_prs`, this does not re-check closed-unmerged: those are
+ * already filtered out at sync time (get_recent_pull_requests) before reaching
+ * the stored list, so none can appear here.
  */
 export function prs_created_in_window<T extends { created_at: string; author_is_bot?: boolean }>(
 	prs: T[],

--- a/src/lib/services/metrics.ts
+++ b/src/lib/services/metrics.ts
@@ -1,0 +1,324 @@
+import type {
+	IPRSizeStats,
+	IPullRequestInfo,
+	IPRContributorStats,
+	IReviewerStats
+} from '../../types';
+
+/**
+ * Pure dashboard-metric aggregation.
+ *
+ * These functions take already-fetched, normalized records plus the date window
+ * and return the shapes the dashboard renders. They are the single source of
+ * truth for what each metric means, and contain NO GitHub/Octokit/filesystem
+ * dependencies so they can be unit-tested in isolation.
+ *
+ * Canonical definitions (see issue #6):
+ * - Windowing is by EVENT date: a review counts when its `submitted_at` falls in
+ *   the window; a comment when its `created_at` does. A PR's own age never pulls
+ *   historical activity into the window.
+ * - A "review" is a submitted review whose state is APPROVED, CHANGES_REQUESTED,
+ *   or COMMENTED. DISMISSED and PENDING do not count. This applies to both the
+ *   daily grid (review events) and the distinct-PRs-reviewed column.
+ * - "Comments" are inline review (diff) comments only.
+ * - Self-reviews and self-comments (actor == PR author) are excluded everywhere.
+ * - Bots are excluded from every metric by default.
+ * - Avg days-to-merge is over merged PRs only; open PRs are never averaged in.
+ * - PR sizes and contributor "total PRs" both measure PRs CREATED in the window.
+ */
+
+/** Review states that count as having reviewed a PR. */
+export const QUALIFYING_REVIEW_STATES = new Set(['APPROVED', 'CHANGES_REQUESTED', 'COMMENTED']);
+
+/** A normalized review event (one submitted GitHub review). */
+export interface ReviewRecord {
+	pr_number: number;
+	pr_author: string;
+	reviewer: string;
+	reviewer_is_bot: boolean;
+	state: string;
+	submitted_at: string | null;
+}
+
+/** A normalized inline review comment. */
+export interface CommentRecord {
+	pr_number: number;
+	pr_author: string;
+	author: string;
+	author_is_bot: boolean;
+	created_at: string;
+}
+
+/** A normalized pull request with the fields every metric needs. */
+export interface PullRequestRecord {
+	number: number;
+	author: string;
+	author_is_bot: boolean;
+	title: string;
+	html_url: string;
+	additions: number;
+	deletions: number;
+	created_at: string;
+	merged_at: string | null;
+	state: 'open' | 'closed';
+}
+
+/**
+ * A PR closed without being merged. A merged PR is also state 'closed' but
+ * carries a merged_at timestamp; one closed without merging has none. These
+ * never merged and must not count toward any metric.
+ */
+export function is_closed_unmerged(pr: { state: string; merged_at: string | null }): boolean {
+	return pr.state === 'closed' && !pr.merged_at;
+}
+
+/**
+ * Whether a GitHub user is a bot. GitHub sets `type: 'Bot'` on bot accounts;
+ * the `[bot]` login suffix is a defensive fallback for any payload missing it.
+ */
+export function is_bot_user(user: { login?: string | null; type?: string | null } | null): boolean {
+	if (!user) return false;
+	if (user.type === 'Bot') return true;
+	return /\[bot\]$/i.test(user.login ?? '');
+}
+
+/** Inclusive YYYY-MM-DD comparison of an ISO timestamp against the window edges. */
+function date_in_window(iso: string | null, dates: string[]): boolean {
+	if (!iso || dates.length === 0) return false;
+	const day = iso.split('T')[0];
+	return day >= dates[0] && day <= dates[dates.length - 1];
+}
+
+/** A review that counts: qualifying state, in window, not a self-review, not a bot. */
+export function is_counted_review(review: ReviewRecord, dates: string[]): boolean {
+	return (
+		QUALIFYING_REVIEW_STATES.has(review.state) &&
+		date_in_window(review.submitted_at, dates) &&
+		review.reviewer !== review.pr_author &&
+		!review.reviewer_is_bot
+	);
+}
+
+/** A comment that counts: in window, not a self-comment, not a bot. */
+export function is_counted_comment(comment: CommentRecord, dates: string[]): boolean {
+	return (
+		date_in_window(comment.created_at, dates) &&
+		comment.author !== comment.pr_author &&
+		!comment.author_is_bot
+	);
+}
+
+/** Days between creation and merge for a merged PR; null for anything not merged. */
+export function days_to_merge(pr: { created_at: string; merged_at: string | null }): number | null {
+	if (!pr.merged_at) return null;
+	const created = new Date(pr.created_at).getTime();
+	const merged = new Date(pr.merged_at).getTime();
+	return Math.ceil((merged - created) / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Daily review grid: count of qualifying review EVENTS per reviewer per day.
+ * Re-reviewing the same PR multiple times in a day counts each event.
+ */
+export function count_reviews_per_day(
+	reviews: ReviewRecord[],
+	dates: string[]
+): Record<string, Record<string, number>> {
+	const result: Record<string, Record<string, number>> = {};
+
+	for (const review of reviews) {
+		if (!is_counted_review(review, dates)) continue;
+
+		const day = review.submitted_at!.split('T')[0];
+		if (!result[review.reviewer]) {
+			result[review.reviewer] = {};
+			dates.forEach((d) => (result[review.reviewer][d] = 0));
+		}
+		result[review.reviewer][day]++;
+	}
+
+	return result;
+}
+
+/**
+ * Per-reviewer stats: DISTINCT PRs reviewed (qualifying reviews in window) and
+ * the count of qualifying inline comments left. Keyed by reviewer login.
+ */
+export function calculate_reviewer_stats(
+	reviews: ReviewRecord[],
+	comments: CommentRecord[],
+	dates: string[]
+): Record<string, IReviewerStats> {
+	const reviewer_prs = new Map<string, Set<number>>();
+	for (const review of reviews) {
+		if (!is_counted_review(review, dates)) continue;
+		if (!reviewer_prs.has(review.reviewer)) reviewer_prs.set(review.reviewer, new Set());
+		reviewer_prs.get(review.reviewer)!.add(review.pr_number);
+	}
+
+	const reviewer_comments = new Map<string, number>();
+	for (const comment of comments) {
+		if (!is_counted_comment(comment, dates)) continue;
+		reviewer_comments.set(comment.author, (reviewer_comments.get(comment.author) ?? 0) + 1);
+	}
+
+	const result: Record<string, IReviewerStats> = {};
+	const all_reviewers = new Set([...reviewer_prs.keys(), ...reviewer_comments.keys()]);
+
+	for (const reviewer of all_reviewers) {
+		const reviewed_prs = reviewer_prs.get(reviewer);
+		const prs_reviewed = reviewed_prs?.size ?? 0;
+		const total_comments = reviewer_comments.get(reviewer) ?? 0;
+
+		result[reviewer] = {
+			reviewer,
+			total_prs_reviewed: prs_reviewed,
+			total_review_comments: total_comments,
+			avg_comments_per_pr:
+				prs_reviewed > 0 ? Math.round((total_comments / prs_reviewed) * 10) / 10 : 0,
+			reviewed_pr_numbers: reviewed_prs ? [...reviewed_prs] : []
+		};
+	}
+
+	return result;
+}
+
+/** PRs created in the window that count toward contribution metrics. */
+function contribution_prs(
+	prs: PullRequestRecord[],
+	excluded: Set<number>,
+	dates: string[]
+): PullRequestRecord[] {
+	return prs.filter((pr) => {
+		if (is_closed_unmerged(pr)) return false;
+		if (excluded.has(pr.number)) return false;
+		if (pr.author_is_bot) return false;
+		const created = pr.created_at.split('T')[0];
+		return created >= dates[0] && created <= dates[dates.length - 1];
+	});
+}
+
+/**
+ * Per-author PR size stats over PRs CREATED in the window (excluding
+ * closed-unmerged, excluded, and bot-authored PRs).
+ */
+export function calculate_pr_sizes(
+	prs: PullRequestRecord[],
+	excluded: Set<number>,
+	dates: string[]
+): Record<string, IPRSizeStats> {
+	const sizes_by_author: Record<string, number[]> = {};
+
+	for (const pr of contribution_prs(prs, excluded, dates)) {
+		const size = pr.additions + pr.deletions;
+		if (!sizes_by_author[pr.author]) sizes_by_author[pr.author] = [];
+		sizes_by_author[pr.author].push(size);
+	}
+
+	const result: Record<string, IPRSizeStats> = {};
+	for (const [author, sizes] of Object.entries(sizes_by_author)) {
+		if (sizes.length === 0) continue;
+		result[author] = {
+			min: Math.min(...sizes),
+			max: Math.max(...sizes),
+			avg: Math.round(sizes.reduce((sum, s) => sum + s, 0) / sizes.length),
+			pr_count: sizes.length
+		};
+	}
+
+	return result;
+}
+
+/**
+ * Qualifying inline comments grouped by the PR they were left on. Used both at
+ * sync time (from raw comments) and as the input the contributor-stats assembly
+ * consumes, so the recalculate path can supply already-stored per-PR counts.
+ */
+export function count_comments_by_pr(
+	comments: CommentRecord[],
+	dates: string[]
+): Map<number, number> {
+	const comments_by_pr = new Map<number, number>();
+	for (const comment of comments) {
+		if (!is_counted_comment(comment, dates)) continue;
+		comments_by_pr.set(comment.pr_number, (comments_by_pr.get(comment.pr_number) ?? 0) + 1);
+	}
+	return comments_by_pr;
+}
+
+/**
+ * Per-author contribution stats over PRs CREATED in the window. Days-to-merge is
+ * computed for merged PRs only (open PRs contribute null and are excluded from
+ * the average). `comments_by_pr` is the qualifying comments-received count per PR
+ * (build it with `count_comments_by_pr`).
+ */
+export function calculate_contributor_stats(
+	prs: PullRequestRecord[],
+	comments_by_pr: Map<number, number>,
+	excluded: Set<number>,
+	dates: string[]
+): IPRContributorStats[] {
+	const stats_by_author = new Map<string, IPRContributorStats>();
+
+	for (const pr of contribution_prs(prs, excluded, dates)) {
+		if (!stats_by_author.has(pr.author)) {
+			const prs_by_date: Record<string, number> = {};
+			dates.forEach((d) => (prs_by_date[d] = 0));
+			stats_by_author.set(pr.author, {
+				author: pr.author,
+				prs_by_date,
+				prs: [],
+				avg_days_to_merge: null,
+				avg_review_comments: 0,
+				total_prs: 0
+			});
+		}
+
+		const stats = stats_by_author.get(pr.author)!;
+		const created_date = pr.created_at.split('T')[0];
+		if (stats.prs_by_date[created_date] !== undefined) stats.prs_by_date[created_date]++;
+
+		const review_comments_count = comments_by_pr.get(pr.number) ?? 0;
+		stats.prs.push({
+			number: pr.number,
+			title: pr.title,
+			html_url: pr.html_url,
+			created_at: pr.created_at,
+			merged_at: pr.merged_at,
+			state: pr.state,
+			days_to_merge: days_to_merge(pr),
+			review_comments_count
+		});
+		stats.total_prs++;
+	}
+
+	for (const stats of stats_by_author.values()) {
+		const merged = stats.prs.filter((pr) => pr.days_to_merge !== null);
+		if (merged.length > 0) {
+			const total_days = merged.reduce((sum, pr) => sum + (pr.days_to_merge ?? 0), 0);
+			stats.avg_days_to_merge = Math.round((total_days / merged.length) * 10) / 10;
+		}
+
+		const total_comments = stats.prs.reduce((sum, pr) => sum + pr.review_comments_count, 0);
+		stats.avg_review_comments =
+			stats.prs.length > 0 ? Math.round((total_comments / stats.prs.length) * 10) / 10 : 0;
+	}
+
+	return Array.from(stats_by_author.values()).sort((a, b) => b.total_prs - a.total_prs);
+}
+
+/** Convert a stored PR (used by the recalculate path) to a metrics record. */
+export function record_from_stored(pr: IPullRequestInfo): PullRequestRecord {
+	return {
+		number: pr.number,
+		author: pr.author,
+		author_is_bot: pr.author_is_bot ?? false,
+		title: pr.title,
+		html_url: pr.html_url,
+		additions: pr.additions,
+		deletions: pr.deletions,
+		created_at: pr.created_at,
+		merged_at: pr.merged_at,
+		state: pr.state
+	};
+}

--- a/src/lib/services/metrics.ts
+++ b/src/lib/services/metrics.ts
@@ -94,6 +94,39 @@ function date_in_window(iso: string | null, dates: string[]): boolean {
 	return day >= dates[0] && day <= dates[dates.length - 1];
 }
 
+/**
+ * The window of YYYY-MM-DD day strings ending today, oldest first. `now` is
+ * injectable so the window is deterministic in tests.
+ */
+export function get_date_range(numberOfDays = 14, now: Date = new Date()): string[] {
+	const dates: string[] = [];
+	for (let i = 0; i < numberOfDays; i++) {
+		const date = new Date(now);
+		date.setDate(date.getDate() - i);
+		dates.unshift(date.toISOString().split('T')[0]);
+	}
+	return dates;
+}
+
+/**
+ * PRs created within the window, authored by a human. This is the set the
+ * contributors view should show — matching the dashboard's "PRs created in the
+ * window" definition — rather than every PR merely *updated* in the window
+ * (which drags in ancient PRs that received recent activity). Excluded PRs are
+ * intentionally kept so the contributors view can still display/toggle them.
+ */
+export function prs_created_in_window<T extends { created_at: string; author_is_bot?: boolean }>(
+	prs: T[],
+	dates: string[]
+): T[] {
+	if (dates.length === 0) return [];
+	return prs.filter((pr) => {
+		if (pr.author_is_bot) return false;
+		const created = pr.created_at.split('T')[0];
+		return created >= dates[0] && created <= dates[dates.length - 1];
+	});
+}
+
 /** A review that counts: qualifying state, in window, not a self-review, not a bot. */
 export function is_counted_review(review: ReviewRecord, dates: string[]): boolean {
 	return (

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -265,7 +265,7 @@
 			<section class="pr-sizes-section">
 				<h2>Average PR Size (Lines Changed)</h2>
 				<p class="section-description">
-					PR size statistics for all PRs with activity in the last 14 days
+					PR size statistics for PRs opened (created) within the last 14 days
 				</p>
 
 				<div class="pr-sizes-table">

--- a/src/routes/contributors/+page.server.ts
+++ b/src/routes/contributors/+page.server.ts
@@ -2,6 +2,7 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { CodeReviewsService } from '$lib/services/code-reviews';
 import { ExclusionsService } from '$lib/services/exclusions';
+import { get_date_range, prs_created_in_window } from '$lib/services/metrics';
 import { ApiError } from '$lib/utils/api-error';
 import { ApiResponse } from '$lib/utils/api-response';
 
@@ -13,8 +14,14 @@ export const load: PageServerLoad = async () => {
 		const sync_data = await code_review_service.get_synced_data();
 		const exclusions = await exclusions_service.get_excluded_prs();
 
+		// Scope to PRs created in the window (and authored by humans), matching the
+		// dashboard's "PRs created in the window" definition. The stored list holds
+		// every PR *updated* in the window, which drags in ancient PRs that merely
+		// received recent activity — inflating per-author counts on this page.
+		const pull_requests = prs_created_in_window(sync_data.pull_requests ?? [], get_date_range());
+
 		return {
-			pull_requests: sync_data.pull_requests ?? [],
+			pull_requests,
 			excluded: exclusions.excluded,
 			status: sync_data.status,
 			last_synced: sync_data.last_synced

--- a/src/routes/page.svelte.test.ts
+++ b/src/routes/page.svelte.test.ts
@@ -68,7 +68,7 @@ describe('/+page.svelte', () => {
 		});
 		expect(screen.getByText('Average PR Size (Lines Changed)')).toBeInTheDocument();
 		expect(
-			screen.getByText('PR size statistics for all PRs with activity in the last 14 days')
+			screen.getByText('PR size statistics for PRs opened (created) within the last 14 days')
 		).toBeInTheDocument();
 	});
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,9 @@ export interface IPullRequestInfo {
 	title: string;
 	html_url: string;
 	author: string;
+	// Whether the PR author is a bot. Optional for backwards compatibility with
+	// data.json written before bot exclusion existed; treated as false when absent.
+	author_is_bot?: boolean;
 	additions: number;
 	deletions: number;
 	created_at: string;


### PR DESCRIPTION
Closes #6.

## Problem

The dashboard reported impossible numbers — one engineer showed **255 "PRs Reviewed" in 14 days**, spanning PR #206–#1888. `calculate_reviewer_stats` counted **all-time** reviews and comments on any PR merely *updated* in the window, never filtering by when the review/comment actually happened. The daily grid filtered correctly; the summary columns did not. Two further issues: Avg Days to Merge was contaminated by open PRs (counted by age), and bots were counted as reviewers/commenters.

## Approach

Extract a pure, fully unit-tested metrics module (`src/lib/services/metrics.ts`) that is the single source of truth for every metric. `CodeReviewsService` now normalizes raw GitHub responses into records (carrying `submitted_at`, `state`, `created_at`, and bot flags) and delegates all aggregation to it. Reviews are fetched once (previously twice).

## Canonical definitions enforced (agreed in #6)

- **Windowing by event date** — reviews by `submitted_at`, comments by `created_at`. A PR's age never pulls historical activity into the window.
- **Review = state APPROVED / CHANGES_REQUESTED / COMMENTED** (DISMISSED/PENDING dropped), applied to both the daily grid (events) and PRs Reviewed (distinct PRs).
- **Comments = inline review comments only**, self- and bot-activity excluded.
- **Bots excluded from every metric** (`type === 'Bot'` / `[bot]` login).
- **Avg Days to Merge = merged PRs only**; open PRs no longer counted by age (per-PR shows "–").
- **PR Size and Total PRs both measure PRs created in the window.**

## Tests

`metrics.test.ts` — 24 unit tests covering: in-window review on an old PR counts; out-of-window review on a recently-updated PR doesn't; dismissed/pending excluded; re-reviewing one PR = 1 distinct PR but N grid events; bots excluded; open PRs excluded from days-to-merge; PR Size uses created-in-window; comments-received counts qualifying comments only.

Full suite: **68 pass** (was 44). `npm run check`: 0 errors. Lint clean.

## How to test
1. Pull the branch, `npm run check` and `npm run test:unit -- --run` (68 pass).
2. **Re-sync is required** for live numbers to change — `data.json` stores only derived values, so the fix takes effect on the next sync. After re-syncing, the inflated "PRs Reviewed" drops to the real in-window distinct-PR count, bots disappear from the tables, and Avg Days to Merge reflects merged PRs only.
3. Dashboard renders unchanged structurally (verified: 6 rows, 9 team scores, PR Sizes section).

## Notes
- **Requires a re-sync** to take effect (the raw timestamps/states needed to recompute were previously discarded).
- **Superseded by #4** (Postgres migration), which reimplements these as query-time filters using the same definitions — #4 was updated with a canonical metric-definitions section so the behavior is preserved.