### PR TITLE
Exclude draft PRs from all calculations

### DIFF
--- a/src/lib/services/code-reviews.ts
+++ b/src/lib/services/code-reviews.ts
@@ -259,7 +259,8 @@ export class CodeReviewsService {
 				deletions: pr.deletions ?? 0,
 				created_at: pr.created_at,
 				merged_at: pr.merged_at,
-				state: pr.state as 'open' | 'closed'
+				state: pr.state as 'open' | 'closed',
+				is_draft: pr.draft ?? false
 			}));
 	}
 
@@ -326,9 +327,10 @@ export class CodeReviewsService {
 					break;
 				}
 
-				// Exclude PRs that were closed without being merged so they never
-				// enter any downstream metric, the stored list, or the UI.
-				if (is_closed_unmerged(pr)) {
+				// Exclude closed-unmerged and draft PRs so neither ever enters a
+				// downstream metric, the stored list, or the UI. Drafts are
+				// work-in-progress, not real contributions or review targets.
+				if (is_closed_unmerged(pr) || pr.draft) {
 					continue;
 				}
 

--- a/src/lib/services/metrics.test.ts
+++ b/src/lib/services/metrics.test.ts
@@ -73,6 +73,7 @@ function pr(over: Partial<PullRequestRecord> = {}): PullRequestRecord {
 		created_at: IN,
 		merged_at: null,
 		state: 'open',
+		is_draft: false,
 		...over
 	};
 }
@@ -325,11 +326,12 @@ describe('calculate_pr_sizes', () => {
 		expect(sizes['dev']).toEqual({ min: 100, max: 100, avg: 100, pr_count: 2 });
 	});
 
-	it('excludes closed-unmerged, excluded, and bot-authored PRs', () => {
+	it('excludes closed-unmerged, excluded, bot-authored, and draft PRs', () => {
 		const prs = [
 			pr({ number: 1, author: 'dev', state: 'closed', merged_at: null }), // closed-unmerged
 			pr({ number: 2, author: 'dev' }), // excluded by id
-			pr({ number: 3, author: 'bot', author_is_bot: true })
+			pr({ number: 3, author: 'bot', author_is_bot: true }),
+			pr({ number: 4, author: 'dev', is_draft: true }) // draft
 		];
 		expect(calculate_pr_sizes(prs, new Set([2]), DATES)).toEqual({});
 	});
@@ -374,6 +376,16 @@ describe('calculate_contributor_stats', () => {
 		const [stats] = calculate_contributor_stats(prs, counts, new Set(), DATES);
 		expect(stats.prs[0].review_comments_count).toBe(2);
 		expect(stats.avg_review_comments).toBe(2);
+	});
+
+	it('excludes draft PRs from contributor stats', () => {
+		const prs = [
+			pr({ number: 1, author: 'dev', created_at: '2026-06-05T00:00:00Z' }),
+			pr({ number: 2, author: 'dev', created_at: '2026-06-05T00:00:00Z', is_draft: true })
+		];
+		const [stats] = calculate_contributor_stats(prs, new Map(), new Set(), DATES);
+		expect(stats.total_prs).toBe(1);
+		expect(stats.prs.map((p) => p.number)).toEqual([1]);
 	});
 
 	it('buckets PRs by their creation date', () => {

--- a/src/lib/services/metrics.test.ts
+++ b/src/lib/services/metrics.test.ts
@@ -190,6 +190,22 @@ describe('record_from_stored', () => {
 		};
 		expect(record_from_stored(stored).author_is_bot).toBe(true);
 	});
+
+	it('always marks stored PRs as non-draft (drafts are never stored)', () => {
+		const stored = {
+			number: 3,
+			title: 'PR',
+			html_url: 'https://example.com/3',
+			author: 'dev',
+			additions: 1,
+			deletions: 1,
+			created_at: IN,
+			merged_at: null,
+			state: 'open' as const,
+			review_comments_count: 0
+		};
+		expect(record_from_stored(stored).is_draft).toBe(false);
+	});
 });
 
 describe('get_date_range', () => {

--- a/src/lib/services/metrics.ts
+++ b/src/lib/services/metrics.ts
@@ -117,9 +117,12 @@ export function get_date_range(numberOfDays = 14, now: Date = new Date()): strin
  * (which drags in ancient PRs that received recent activity). Excluded PRs are
  * intentionally kept so the contributors view can still display/toggle them.
  *
- * Unlike `contribution_prs`, this does not re-check closed-unmerged: those are
- * already filtered out at sync time (get_recent_pull_requests) before reaching
- * the stored list, so none can appear here.
+ * Unlike `contribution_prs`, this does not re-check closed-unmerged or draft
+ * status: both are filtered out at sync time (get_recent_pull_requests) before
+ * reaching the stored list, and `IPullRequestInfo` carries no draft flag. The
+ * accepted trade-off (same as closed-unmerged) is that if an author converts an
+ * already-stored PR back to draft between syncs, the stale entry stays visible
+ * here until the next sync re-fetches and drops it.
  */
 export function prs_created_in_window<T extends { created_at: string; author_is_bot?: boolean }>(
 	prs: T[],

--- a/src/lib/services/metrics.ts
+++ b/src/lib/services/metrics.ts
@@ -25,6 +25,7 @@ import type {
  * - Bots are excluded from every metric by default.
  * - Avg days-to-merge is over merged PRs only; open PRs are never averaged in.
  * - PR sizes and contributor "total PRs" both measure PRs CREATED in the window.
+ * - Draft and closed-unmerged PRs are excluded from every metric.
  */
 
 /** Review states that count as having reviewed a PR. */
@@ -61,6 +62,7 @@ export interface PullRequestRecord {
 	created_at: string;
 	merged_at: string | null;
 	state: 'open' | 'closed';
+	is_draft: boolean;
 }
 
 /**
@@ -236,7 +238,7 @@ function contribution_prs(
 	dates: string[]
 ): PullRequestRecord[] {
 	return prs.filter((pr) => {
-		if (is_closed_unmerged(pr)) return false;
+		if (is_closed_unmerged(pr) || pr.is_draft) return false;
 		if (excluded.has(pr.number)) return false;
 		if (pr.author_is_bot) return false;
 		const created = pr.created_at.split('T')[0];
@@ -365,6 +367,8 @@ export function record_from_stored(pr: IPullRequestInfo): PullRequestRecord {
 		deletions: pr.deletions,
 		created_at: pr.created_at,
 		merged_at: pr.merged_at,
-		state: pr.state
+		state: pr.state,
+		// Drafts are filtered out at fetch time, so a stored PR is never a draft.
+		is_draft: false
 	};
 }


### PR DESCRIPTION
## Problem

Draft PRs were being counted in our metrics. Example: a large draft (#1921, 2,932 additions, opened today) showed up in its author's contributor stats and PR-size totals. Drafts are work-in-progress, not real contributions or review targets, and shouldn't count.

The fetch only excluded **closed-unmerged** PRs (`is_closed_unmerged`); drafts slipped through into the stored list and every PR-authorship metric.

## Fix

Mirror exactly how closed-unmerged is handled — exclude drafts at two layers:

1. **Fetch (`get_recent_pull_requests`)** — skip `pr.draft` alongside closed-unmerged, so drafts never enter the stored list, any metric, or review/comment fetching.
2. **Pure metric layer (`contribution_prs`)** — defensive `is_draft` check (added `is_draft` to `PullRequestRecord`), so PR sizes and contributor stats independently exclude drafts. `record_from_stored` sets `is_draft: false` (drafts are never stored, given the fetch filter).

## Tests

Added draft-exclusion cases to `calculate_pr_sizes` and `calculate_contributor_stats`. Full suite: **80 pass**. `npm run check` clean, lint clean.

## Verified end-to-end

Clicked the real **Sync Code Reviews** button and re-synced against live data. After the sync:
- #1921 is **no longer** in the stored `pull_requests` list.
- #1921 is **no longer** in `otutukingsley`'s contributor stats (his total dropped to 25).
- Dashboard reloaded cleanly.

## How to test
1. Pull the branch, `npm run test:unit -- --run` (80 pass).
2. Sync from the dashboard; confirm draft PRs no longer appear under their authors on `/contributors` or in PR-size/contributor metrics.

## Notes
- **Requires a re-sync** to take effect — existing `data.json` still contains drafts until re-fetched.
- One intended consequence: reviews/comments left on a *currently-draft* PR are not counted (the draft isn't fetched). A PR that was a draft but is now marked ready (`draft = false`) is included normally.
- Will be carried into the Postgres migration (#4) — I'll add `draft` to the schema and the canonical definitions there.